### PR TITLE
feat: rename CLI binary to amigo-dl and enhance direct download funct…

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,32 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(cargo check:*)",
+      "Bash(xargs grep:*)",
+      "Bash(cargo build:*)",
+      "Bash(./target/release/amigo-dl \"https://www.youtube.com/watch?v=1mzl2Oo8Ncw\" -o ./test-downloads 2>&1)",
+      "Bash(RUST_LOG=debug ./target/release/amigo-dl \"https://www.youtube.com/watch?v=1mzl2Oo8Ncw\" -o ./test-downloads)",
+      "Bash(curl -sL \"https://api.github.com/repos/yt-dlp/yt-dlp/contents/yt_dlp/extractor/youtube\")",
+      "Bash(python3 -c \"import sys,json; [print\\(f[''''name''''], f[''''type'''']\\) for f in json.load\\(sys.stdin\\)]\")",
+      "Bash(curl -sL https://api.github.com/repos/yt-dlp/yt-dlp/contents/yt_dlp/extractor/youtube)",
+      "Bash(jq -r \".[] | \"\"\\\\\\(.name\\) \\\\\\(.type\\)\"\"\")",
+      "WebFetch(domain:raw.githubusercontent.com)",
+      "Bash(curl -sI \"https://raw.githubusercontent.com/yt-dlp/yt-dlp/master/yt_dlp/extractor/youtube.py\")",
+      "Bash(curl -sL \"https://api.github.com/repos/yt-dlp/yt-dlp\")",
+      "Bash(python3 -c \"import sys,json; d=json.load\\(sys.stdin\\); print\\(''''default_branch:'''', d.get\\(''''default_branch''''\\)\\); print\\(''''size:'''', d.get\\(''''size''''\\)\\)\")",
+      "Bash(curl -sL \"https://api.github.com/repos/yt-dlp/yt-dlp/contents/yt_dlp/extractor\")",
+      "Bash(gh api:*)",
+      "Bash(curl -sL \"https://api.github.com/repos/yt-dlp/yt-dlp/git/trees/master?recursive=1\")",
+      "Bash(curl -sL \"https://raw.githubusercontent.com/yt-dlp/yt-dlp/master/yt_dlp/extractor/youtube/_base.py\" -o /tmp/yt_base.py)",
+      "Read(//tmp/**)",
+      "Bash(curl -sL \"https://raw.githubusercontent.com/yt-dlp/yt-dlp/master/yt_dlp/extractor/youtube/_video.py\" -o /tmp/yt_video.py)",
+      "Bash(curl -sL \"https://raw.githubusercontent.com/yt-dlp/yt-dlp/master/yt_dlp/extractor/youtube/pot/provider.py\" -o /tmp/yt_pot_provider.py)",
+      "Bash(curl -sL \"https://raw.githubusercontent.com/yt-dlp/yt-dlp/master/yt_dlp/extractor/youtube/pot/utils.py\" -o /tmp/yt_pot_utils.py)",
+      "Bash(curl -sL \"https://raw.githubusercontent.com/yt-dlp/yt-dlp/master/yt_dlp/extractor/youtube/pot/_provider.py\" -o /tmp/yt_pot__provider.py)",
+      "Read(//c/tmp/**)",
+      "Bash(curl -sL \"https://raw.githubusercontent.com/yt-dlp/yt-dlp/master/yt_dlp/extractor/youtube/jsc/provider.py\" -o /tmp/yt_jsc_provider.py)",
+      "Bash(curl -sL \"https://raw.githubusercontent.com/yt-dlp/yt-dlp/master/yt_dlp/extractor/youtube/jsc/_builtin/ejs.py\" -o /tmp/yt_ejs.py)",
+      "Bash(git:*)"
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -362,16 +362,21 @@ WS     /api/v1/ws
 ## CLI
 
 ```bash
-amigo add <URL>
-amigo add --nzb <file.nzb>
-amigo add --torrent <file.torrent>
-amigo add --magnet "<magnet:?...>"
-amigo add --dlc <file.dlc>              # DLC Import
-amigo export-dlc [--ids <id1,id2,...>]   # DLC Export
-amigo list / pause / resume / cancel / queue / status / speed
-amigo config get/set <key> <value>
-amigo plugins list / enable / login
-amigo serve [--port 8080 --bind 0.0.0.0]
+# Direct download — just pass URLs (like yt-dlp)
+amigo-dl <URL> [URL...]
+amigo-dl <URL> -o ./downloads --chunks 8
+
+# Queue-based (adds to DB, used with server)
+amigo-dl add <URL>
+amigo-dl add --nzb <file.nzb>
+amigo-dl add --torrent <file.torrent>
+amigo-dl add --magnet "<magnet:?...>"
+amigo-dl add --dlc <file.dlc>              # DLC Import
+amigo-dl export-dlc [--ids <id1,id2,...>]   # DLC Export
+amigo-dl list / pause / resume / cancel / queue / status / speed
+amigo-dl config get/set <key> <value>
+amigo-dl plugins list / enable / login
+amigo-dl serve [--port 8080 --bind 0.0.0.0]
 ```
 
 ---

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ tower-http = { version = "0.6", features = ["cors", "fs"] }
 
 # CLI
 clap = { version = "4", features = ["derive"] }
+indicatif = "0.17"
 
 # UUID
 uuid = { version = "1", features = ["v4", "serde"] }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   <h1>amigo-downloader</h1>
 
   <p><strong>Fast, modular download manager</strong> built in Rust with a responsive Web UI, plugin system, and native apps.</p>
-  <p>Faster than JDownloader, lighter than pyLoad, extensible for HTTP, Usenet, and more.</p>
+  <p>Extensible for HTTP, Usenet, and more.</p>
 
   <p>
     <a href="https://github.com/amigo-labs/amigo-downloader/actions"><img src="https://img.shields.io/github/actions/workflow/status/amigo-labs/amigo-downloader/ci.yml?branch=main&style=flat-square&logo=github&label=CI" alt="CI" /></a>
@@ -57,11 +57,80 @@ cargo run --release --bin amigo-server
 ### CLI
 
 ```bash
-cargo run --release --bin amigo -- add https://example.com/file.zip
-cargo run --release --bin amigo -- list
-cargo run --release --bin amigo -- add --nzb file.nzb
-cargo run --release --bin amigo -- add --dlc links.dlc
+amigo-dl https://example.com/file.zip
 ```
+
+<details>
+<summary><strong>CLI reference</strong></summary>
+
+#### Direct download
+
+Just pass URLs — downloads directly with a progress bar, like yt-dlp.
+
+```bash
+amigo-dl <URL> [URL...]
+amigo-dl <URL> -o ./downloads          # custom output directory
+amigo-dl <URL> --chunks 8              # force 8 parallel chunks
+```
+
+| Option | Short | Default | Description |
+|--------|-------|---------|-------------|
+| `--output` | `-o` | `.` | Output directory |
+| `--chunks` | `-c` | `0` (auto) | Chunks per download, 0 = auto based on file size |
+
+#### Queue management
+
+For use with the server/web UI — adds downloads to the database.
+
+```bash
+amigo-dl add <URL>                     # queue a URL
+amigo-dl add --nzb file.nzb            # import NZB
+amigo-dl add --dlc links.dlc           # import DLC container
+amigo-dl list                          # list active downloads
+amigo-dl pause <ID>                    # pause a download
+amigo-dl resume <ID>                   # resume a download
+amigo-dl cancel <ID>                   # cancel and remove
+amigo-dl queue                         # show queue
+amigo-dl status                        # overview (active, queued, speed)
+amigo-dl speed                         # current download speed
+```
+
+#### DLC containers
+
+```bash
+amigo-dl add --dlc links.dlc           # import
+amigo-dl export-dlc                    # export all
+amigo-dl export-dlc --ids id1,id2      # export specific
+```
+
+#### Configuration
+
+```bash
+amigo-dl config get <key>              # read a config value
+amigo-dl config set <key> <value>      # write a config value
+```
+
+#### Plugins
+
+```bash
+amigo-dl plugins list                  # list installed plugins
+amigo-dl plugins install <id>          # install from registry
+amigo-dl plugins update [id]           # update plugins
+amigo-dl plugins search <query>        # search registry
+amigo-dl plugins enable <id>           # enable a plugin
+amigo-dl plugins login <id>            # login to a hoster account
+```
+
+#### Server & updates
+
+```bash
+amigo-dl serve                         # start REST API (port 8080)
+amigo-dl serve --port 9090 --bind 127.0.0.1
+amigo-dl update check                  # check for new version
+amigo-dl update apply --yes            # apply update
+```
+
+</details>
 
 ## Architecture
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 license.workspace = true
 
 [[bin]]
-name = "amigo"
+name = "amigo-dl"
 path = "src/main.rs"
 
 [dependencies]
@@ -18,3 +18,4 @@ tracing-subscriber = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { workspace = true }
 axum = { workspace = true }
+indicatif = { workspace = true }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -2,22 +2,48 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use clap::{Parser, Subcommand};
+use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
+use tokio::sync::watch;
 
 use amigo_core::config::Config;
 use amigo_core::coordinator::Coordinator;
+use amigo_core::protocol::http::{DownloadProgress, HttpDownloader};
+use amigo_core::protocol::youtube;
 use amigo_core::queue::QueueStatus;
 use amigo_core::storage::Storage;
 
 #[derive(Parser)]
-#[command(name = "amigo", about = "amigo-downloader — fast, modular download manager")]
+#[command(name = "amigo-dl", about = "amigo-dl — fast, modular download manager")]
 struct Cli {
+    /// URLs to download directly (no subcommand needed)
+    urls: Vec<String>,
+
+    /// Output directory (for direct downloads)
+    #[arg(short, long, default_value = ".")]
+    output: String,
+
+    /// Number of chunks per download (0 = auto)
+    #[arg(short, long, default_value_t = 0)]
+    chunks: u32,
+
     #[command(subcommand)]
-    command: Commands,
+    command: Option<Commands>,
 }
 
 #[derive(Subcommand)]
 enum Commands {
-    /// Add a download (URL, NZB, or DLC)
+    /// Download URLs directly (explicit form of bare URL usage)
+    Get {
+        /// URLs to download
+        urls: Vec<String>,
+        /// Output directory
+        #[arg(short, long, default_value = ".")]
+        output: String,
+        /// Number of chunks per download (0 = auto)
+        #[arg(short, long, default_value_t = 0)]
+        chunks: u32,
+    },
+    /// Add a download to the queue (URL, NZB, or DLC)
     Add {
         /// URL to download
         url: Option<String>,
@@ -116,11 +142,202 @@ fn init_coordinator() -> anyhow::Result<Arc<Coordinator>> {
     Ok(Arc::new(Coordinator::new(config, storage)))
 }
 
+/// Format bytes as human-readable string.
+fn format_bytes(bytes: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = 1024 * KB;
+    const GB: u64 = 1024 * MB;
+    if bytes >= GB {
+        format!("{:.2} GB", bytes as f64 / GB as f64)
+    } else if bytes >= MB {
+        format!("{:.2} MB", bytes as f64 / MB as f64)
+    } else if bytes >= KB {
+        format!("{:.1} KB", bytes as f64 / KB as f64)
+    } else {
+        format!("{bytes} B")
+    }
+}
+
+/// Extract filename from URL.
+fn filename_from_url(url: &str) -> String {
+    url.rsplit('/')
+        .next()
+        .and_then(|s| s.split('?').next())
+        .filter(|s| !s.is_empty())
+        .unwrap_or("download")
+        .to_string()
+}
+
+/// Resolve a URL — extracts the actual download URL and filename.
+/// For YouTube, this calls the innertube API. For plain URLs, uses HEAD.
+struct ResolvedUrl {
+    download_url: String,
+    filename: String,
+    filesize: Option<u64>,
+    accepts_ranges: bool,
+}
+
+async fn resolve_url(user_agent: &str, url: &str, pb: &ProgressBar) -> anyhow::Result<ResolvedUrl> {
+    if youtube::is_youtube_url(url) {
+        pb.set_message("Resolving YouTube video...");
+        let client = reqwest::Client::builder()
+            .user_agent(user_agent)
+            .build()?;
+        let video = youtube::resolve(&client, url).await?;
+        pb.set_message(format!("{} [{}]", video.title, video.quality));
+
+        Ok(ResolvedUrl {
+            download_url: video.stream_url,
+            filename: video.filename,
+            filesize: video.filesize,
+            // YouTube throttles chunked downloads
+            accepts_ranges: false,
+        })
+    } else {
+        let http = HttpDownloader::new(user_agent);
+        let head = http.head(url).await?;
+        let filename = head
+            .filename
+            .clone()
+            .unwrap_or_else(|| filename_from_url(url));
+
+        Ok(ResolvedUrl {
+            download_url: url.to_string(),
+            filename,
+            filesize: head.content_length,
+            accepts_ranges: head.accepts_ranges,
+        })
+    }
+}
+
+/// Run a direct download for a single URL with terminal progress.
+async fn direct_download(
+    user_agent: &str,
+    url: &str,
+    output_dir: &str,
+    chunks_override: u32,
+    pb: &ProgressBar,
+) -> anyhow::Result<()> {
+    let resolved = resolve_url(user_agent, url, pb).await?;
+
+    let dest = PathBuf::from(output_dir).join(&resolved.filename);
+    tokio::fs::create_dir_all(output_dir).await?;
+
+    pb.set_message(resolved.filename.clone());
+
+    if let Some(total) = resolved.filesize {
+        pb.set_length(total);
+    }
+
+    let (progress_tx, progress_rx) = watch::channel(DownloadProgress {
+        bytes_downloaded: 0,
+        total_bytes: None,
+        speed_bytes_per_sec: 0,
+    });
+
+    // Decide chunk count
+    let max_chunks = if chunks_override > 0 {
+        chunks_override
+    } else {
+        Config::load_auto().http.max_chunks_per_download
+    };
+
+    let use_chunked = resolved.accepts_ranges
+        && resolved.filesize.is_some_and(|s| s > 1024 * 1024)
+        && max_chunks > 1;
+
+    let download_url = resolved.download_url;
+    let filename = resolved.filename;
+    let dest_clone = dest.clone();
+    let temp_dir = PathBuf::from(output_dir).join(".amigo-tmp");
+    tokio::fs::create_dir_all(&temp_dir).await?;
+
+    let ua = user_agent.to_string();
+    let download_handle = if use_chunked {
+        let total = resolved.filesize.unwrap();
+        let num_chunks = max_chunks.min((total / (512 * 1024)).max(1) as u32);
+        let chunk_dir = temp_dir.join(&filename);
+        tokio::fs::create_dir_all(&chunk_dir).await?;
+
+        tokio::spawn(async move {
+            let http = HttpDownloader::new(&ua);
+            http.download_chunked(&download_url, &dest_clone, &chunk_dir, total, num_chunks, progress_tx).await
+        })
+    } else {
+        tokio::spawn(async move {
+            let http = HttpDownloader::new(&ua);
+            http.download_single(&download_url, &dest_clone, progress_tx).await
+        })
+    };
+
+    // Poll progress until download completes
+    let filename_display = filename.clone();
+    loop {
+        if download_handle.is_finished() {
+            break;
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        let p = progress_rx.borrow().clone();
+        pb.set_position(p.bytes_downloaded);
+        if let Some(total) = p.total_bytes {
+            pb.set_length(total);
+        }
+        if p.speed_bytes_per_sec > 0 {
+            pb.set_message(format!("{} — {}/s", filename_display, format_bytes(p.speed_bytes_per_sec)));
+        }
+    }
+
+    let bytes = download_handle.await??;
+    pb.set_position(bytes);
+    pb.finish_with_message(format!("{} — {} done", filename, format_bytes(bytes)));
+
+    // Clean up temp dir if empty
+    let _ = tokio::fs::remove_dir(&temp_dir).await;
+
+    Ok(())
+}
+
+/// Run direct downloads for one or more URLs with progress bars.
+async fn run_direct_downloads(urls: &[String], output: &str, chunks: u32) -> anyhow::Result<()> {
+    if urls.is_empty() {
+        anyhow::bail!("No URLs provided. Usage: amigo-dl <URL> [URL...]");
+    }
+
+    let config = Config::load_auto();
+    let user_agent = config.http.user_agent.clone();
+
+    let multi = MultiProgress::new();
+    let style = ProgressStyle::with_template(
+        "{spinner:.green} [{bar:40.cyan/dim}] {bytes}/{total_bytes} {msg}"
+    )?
+    .progress_chars("━╸─");
+
+    for url in urls {
+        let pb = multi.add(ProgressBar::new(0));
+        pb.set_style(style.clone());
+        direct_download(&user_agent, url, output, chunks, &pb).await?;
+    }
+
+    Ok(())
+}
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
-    match cli.command {
+    // Bare URLs without subcommand → direct download
+    if cli.command.is_none() {
+        if cli.urls.is_empty() {
+            Cli::parse_from(["amigo-dl", "--help"]);
+        }
+        return run_direct_downloads(&cli.urls, &cli.output, cli.chunks).await;
+    }
+
+    match cli.command.unwrap() {
+        Commands::Get { urls, output, chunks } => {
+            run_direct_downloads(&urls, &output, chunks).await?;
+        }
+
         Commands::Add { url, nzb, dlc } => {
             let coord = init_coordinator()?;
             if let Some(url) = url {
@@ -133,7 +350,6 @@ async fn main() -> anyhow::Result<()> {
                 for file in &nzb.files {
                     println!("  {} ({} segments, {} bytes)", file.filename(), file.segments.len(), file.total_bytes());
                 }
-                // Queue each file as a download
                 for file in &nzb.files {
                     let id = coord.add_download(
                         &format!("nzb://{}", file.filename()),
@@ -242,7 +458,7 @@ async fn main() -> anyhow::Result<()> {
             let completed = coord.storage().count_by_status(QueueStatus::Completed).await?;
             let failed = coord.storage().count_by_status(QueueStatus::Failed).await?;
 
-            println!("amigo-downloader v{}", amigo_core::updater::CURRENT_VERSION);
+            println!("amigo-dl v{}", amigo_core::updater::CURRENT_VERSION);
             println!("Active: {active}  Queued: {queued}  Completed: {completed}  Failed: {failed}");
             println!("Speed: {} KB/s", speed / 1024);
         }
@@ -267,7 +483,6 @@ async fn main() -> anyhow::Result<()> {
                     let mut json = serde_json::to_value(&config)?;
                     let pointer = format!("/{}", key.replace('.', "/"));
                     if let Some(field) = json.pointer_mut(&pointer) {
-                        // Try to preserve the type
                         *field = if let Ok(n) = value.parse::<u64>() {
                             serde_json::Value::Number(n.into())
                         } else if let Ok(b) = value.parse::<bool>() {
@@ -299,7 +514,7 @@ async fn main() -> anyhow::Result<()> {
 
         Commands::Plugins { action } => match action {
             PluginAction::List | PluginAction::Enable { .. } | PluginAction::Login { .. } => {
-                println!("Plugin management requires the server. Use: amigo serve");
+                println!("Plugin management requires the server. Use: amigo-dl serve");
             }
             PluginAction::Update { .. } | PluginAction::Install { .. } | PluginAction::Search { .. } => {
                 println!("Plugin updates require the server. Use the web UI or API.");
@@ -347,7 +562,7 @@ async fn main() -> anyhow::Result<()> {
                         }
                         println!("Updating {current} → {latest}...");
                         amigo_core::updater::download_and_apply(&client, &download_url, sha256_url.as_deref()).await?;
-                        println!("Update applied! Restart amigo to use v{latest}.");
+                        println!("Update applied! Restart amigo-dl to use v{latest}.");
                     }
                     amigo_core::updater::CoreUpdateStatus::UpToDate => {
                         println!("Already up to date (v{}).", amigo_core::updater::CURRENT_VERSION);
@@ -365,8 +580,7 @@ async fn main() -> anyhow::Result<()> {
             let coord = init_coordinator()?;
             let listener = tokio::net::TcpListener::bind(&addr).await?;
 
-            let state = std::sync::Arc::new(coord);
-            // Minimal API router for CLI serve mode
+            let _state = std::sync::Arc::new(coord);
             let app = axum::Router::new()
                 .route("/api/v1/status", axum::routing::get(|| async {
                     axum::Json(serde_json::json!({"status": "ok", "version": env!("CARGO_PKG_VERSION"), "mode": "cli"}))

--- a/crates/core/src/protocol/mod.rs
+++ b/crates/core/src/protocol/mod.rs
@@ -1,7 +1,8 @@
-//! Protocol backends: HTTP, Usenet.
+//! Protocol backends: HTTP, Usenet, YouTube.
 
 pub mod http;
 pub mod usenet;
+pub mod youtube;
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/core/src/protocol/youtube.rs
+++ b/crates/core/src/protocol/youtube.rs
@@ -1,0 +1,415 @@
+//! YouTube video stream extraction.
+//!
+//! Extracts direct download URLs from YouTube videos using the innertube API.
+//! Supports watch URLs, short URLs, embed URLs, and Shorts.
+
+use std::collections::HashMap;
+
+use serde_json::Value;
+use tracing::{debug, info, warn};
+
+/// Resolved YouTube video with download-ready stream URL.
+#[derive(Debug, Clone)]
+pub struct YoutubeVideo {
+    pub video_id: String,
+    pub title: String,
+    pub stream_url: String,
+    pub filename: String,
+    pub filesize: Option<u64>,
+    pub mime_type: String,
+    pub quality: String,
+}
+
+/// Extract video ID from various YouTube URL formats.
+pub fn extract_video_id(url: &str) -> Result<String, crate::Error> {
+    // youtube.com/watch?v=ID
+    if let Some(pos) = url.find("v=") {
+        let rest = &url[pos + 2..];
+        let id: String = rest.chars().take_while(|c| c.is_alphanumeric() || *c == '-' || *c == '_').collect();
+        if id.len() == 11 {
+            return Ok(id);
+        }
+    }
+
+    // youtu.be/ID
+    if url.contains("youtu.be/") {
+        if let Some(pos) = url.find("youtu.be/") {
+            let rest = &url[pos + 9..];
+            let id: String = rest.chars().take_while(|c| c.is_alphanumeric() || *c == '-' || *c == '_').collect();
+            if id.len() == 11 {
+                return Ok(id);
+            }
+        }
+    }
+
+    // youtube.com/embed/ID or youtube.com/shorts/ID
+    for prefix in &["/embed/", "/shorts/", "/v/"] {
+        if let Some(pos) = url.find(prefix) {
+            let rest = &url[pos + prefix.len()..];
+            let id: String = rest.chars().take_while(|c| c.is_alphanumeric() || *c == '-' || *c == '_').collect();
+            if id.len() == 11 {
+                return Ok(id);
+            }
+        }
+    }
+
+    Err(crate::Error::Other(format!("Could not extract video ID from: {url}")))
+}
+
+/// Check whether a URL is a YouTube URL.
+pub fn is_youtube_url(url: &str) -> bool {
+    url.contains("youtube.com/") || url.contains("youtu.be/")
+}
+
+/// Fetch video info and select the best stream.
+pub async fn resolve(client: &reqwest::Client, url: &str) -> Result<YoutubeVideo, crate::Error> {
+    let video_id = extract_video_id(url)?;
+    info!("Resolving YouTube video: {video_id}");
+
+    // Try innertube API with Android client (often returns direct URLs)
+    let player = fetch_innertube(client, &video_id).await?;
+
+    let title = player
+        .pointer("/videoDetails/title")
+        .and_then(|v| v.as_str())
+        .unwrap_or("video")
+        .to_string();
+
+    debug!("Video title: {title}");
+
+    // Collect all formats with direct URLs
+    let mut formats = Vec::new();
+
+    // Combined formats (audio + video) — preferred for single-file download
+    if let Some(fmts) = player.pointer("/streamingData/formats").and_then(|v| v.as_array()) {
+        for fmt in fmts {
+            if let Some(info) = parse_format(fmt) {
+                formats.push(info);
+            }
+        }
+    }
+
+    // Adaptive formats as fallback (may be video-only or audio-only)
+    if formats.is_empty() {
+        if let Some(fmts) = player.pointer("/streamingData/adaptiveFormats").and_then(|v| v.as_array()) {
+            for fmt in fmts {
+                if let Some(info) = parse_format(fmt) {
+                    // Prefer formats that have both audio and video
+                    if info.mime_type.starts_with("video/") {
+                        formats.push(info);
+                    }
+                }
+            }
+        }
+    }
+
+    if formats.is_empty() {
+        // Check for playability errors
+        let reason = player
+            .pointer("/playabilityStatus/reason")
+            .and_then(|v| v.as_str())
+            .unwrap_or("No downloadable streams found");
+        return Err(crate::Error::Other(format!("YouTube: {reason}")));
+    }
+
+    // Sort by quality (height descending), prefer combined formats
+    formats.sort_by(|a, b| b.height.cmp(&a.height));
+
+    let best = &formats[0];
+    info!("Selected format: {} ({})", best.quality_label, best.mime_type);
+
+    // Build filename from title
+    let ext = mime_to_ext(&best.mime_type);
+    let safe_title = sanitize_filename(&title);
+    let filename = format!("{safe_title}.{ext}");
+
+    Ok(YoutubeVideo {
+        video_id,
+        title,
+        stream_url: best.url.clone(),
+        filename,
+        filesize: best.content_length,
+        mime_type: best.mime_type.clone(),
+        quality: best.quality_label.clone(),
+    })
+}
+
+/// Intermediate format info for sorting/selection.
+#[derive(Debug)]
+struct FormatInfo {
+    url: String,
+    mime_type: String,
+    quality_label: String,
+    height: u32,
+    content_length: Option<u64>,
+}
+
+fn parse_format(fmt: &Value) -> Option<FormatInfo> {
+    // Must have a direct URL (no signatureCipher)
+    let url = fmt.get("url")?.as_str()?.to_string();
+
+    let mime_full = fmt.get("mimeType")?.as_str().unwrap_or("video/mp4");
+    // Strip codec info: "video/mp4; codecs=\"avc1.42001E\"" → "video/mp4"
+    let mime_type = mime_full.split(';').next().unwrap_or(mime_full).to_string();
+
+    let quality_label = fmt
+        .get("qualityLabel")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown")
+        .to_string();
+
+    let height = fmt.get("height").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
+
+    let content_length = fmt
+        .get("contentLength")
+        .and_then(|v| v.as_str())
+        .and_then(|s| s.parse::<u64>().ok());
+
+    Some(FormatInfo {
+        url,
+        mime_type,
+        quality_label,
+        height,
+        content_length,
+    })
+}
+
+/// Call the YouTube innertube player API.
+async fn fetch_innertube(client: &reqwest::Client, video_id: &str) -> Result<Value, crate::Error> {
+    // Try Android client first — often returns direct URLs without signature cipher
+    let clients: &[(&str, &str, Value)] = &[
+        ("ANDROID", "19.09.37", serde_json::json!({
+            "videoId": video_id,
+            "context": {
+                "client": {
+                    "clientName": "ANDROID",
+                    "clientVersion": "19.09.37",
+                    "androidSdkVersion": 30,
+                    "hl": "en",
+                    "gl": "US",
+                    "userAgent": "com.google.android.youtube/19.09.37 (Linux; U; Android 11) gzip"
+                }
+            }
+        })),
+        ("WEB", "2.20240313", serde_json::json!({
+            "videoId": video_id,
+            "context": {
+                "client": {
+                    "clientName": "WEB",
+                    "clientVersion": "2.20240313.01.00",
+                    "hl": "en",
+                    "gl": "US"
+                }
+            }
+        })),
+    ];
+
+    for (name, _version, body) in clients {
+        debug!("Trying innertube client: {name}");
+
+        let resp = client
+            .post("https://www.youtube.com/youtubei/v1/player?prettyPrint=false")
+            .header("Content-Type", "application/json")
+            .header("X-YouTube-Client-Name", "3")
+            .header("X-YouTube-Client-Version", "19.09.37")
+            .body(body.to_string())
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            warn!("Innertube {name} returned status {}", resp.status());
+            continue;
+        }
+
+        let data: Value = resp.json().await?;
+
+        // Check if we got usable streaming data
+        let status = data
+            .pointer("/playabilityStatus/status")
+            .and_then(|v| v.as_str())
+            .unwrap_or("");
+
+        if status != "OK" {
+            let reason = data
+                .pointer("/playabilityStatus/reason")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown");
+            warn!("Innertube {name}: status={status}, reason={reason}");
+            continue;
+        }
+
+        // Check if formats have direct URLs
+        let has_direct_urls = data
+            .pointer("/streamingData/formats")
+            .and_then(|v| v.as_array())
+            .is_some_and(|fmts| fmts.iter().any(|f| f.get("url").is_some()));
+
+        let has_adaptive_urls = data
+            .pointer("/streamingData/adaptiveFormats")
+            .and_then(|v| v.as_array())
+            .is_some_and(|fmts| fmts.iter().any(|f| f.get("url").is_some()));
+
+        if has_direct_urls || has_adaptive_urls {
+            info!("Got streaming data from innertube client {name}");
+            return Ok(data);
+        }
+
+        debug!("Innertube {name}: no direct URLs in response");
+    }
+
+    // Fallback: try extracting from watch page HTML
+    fetch_from_watch_page(client, video_id).await
+}
+
+/// Fallback: extract player response from the watch page HTML.
+async fn fetch_from_watch_page(client: &reqwest::Client, video_id: &str) -> Result<Value, crate::Error> {
+    debug!("Falling back to watch page extraction");
+
+    let url = format!("https://www.youtube.com/watch?v={video_id}&has_verified=1");
+    let resp = client
+        .get(&url)
+        .header("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36")
+        .header("Accept-Language", "en-US,en;q=0.9")
+        .send()
+        .await?;
+
+    let html = resp.text().await?;
+
+    // Extract ytInitialPlayerResponse
+    let marker = "var ytInitialPlayerResponse = ";
+    let start = html.find(marker)
+        .ok_or_else(|| crate::Error::Other("Could not find ytInitialPlayerResponse in page".into()))?;
+
+    let json_start = start + marker.len();
+    let rest = &html[json_start..];
+
+    // Find the end of the JSON object by counting braces
+    let json_str = extract_json_object(rest)
+        .ok_or_else(|| crate::Error::Other("Could not parse ytInitialPlayerResponse JSON".into()))?;
+
+    let data: Value = serde_json::from_str(json_str)?;
+    Ok(data)
+}
+
+/// Extract a JSON object from a string by matching braces.
+fn extract_json_object(s: &str) -> Option<&str> {
+    if !s.starts_with('{') {
+        return None;
+    }
+
+    let mut depth = 0;
+    let mut in_string = false;
+    let mut escape_next = false;
+
+    for (i, ch) in s.char_indices() {
+        if escape_next {
+            escape_next = false;
+            continue;
+        }
+        match ch {
+            '\\' if in_string => escape_next = true,
+            '"' => in_string = !in_string,
+            '{' if !in_string => depth += 1,
+            '}' if !in_string => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(&s[..=i]);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+fn mime_to_ext(mime: &str) -> &str {
+    match mime {
+        "video/mp4" => "mp4",
+        "video/webm" => "webm",
+        "audio/mp4" => "m4a",
+        "audio/webm" => "weba",
+        _ => "mp4",
+    }
+}
+
+fn sanitize_filename(name: &str) -> String {
+    name.chars()
+        .map(|c| match c {
+            '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|' => '_',
+            _ => c,
+        })
+        .collect::<String>()
+        .trim()
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_video_id_watch() {
+        assert_eq!(
+            extract_video_id("https://www.youtube.com/watch?v=1mzl2Oo8Ncw").unwrap(),
+            "1mzl2Oo8Ncw"
+        );
+    }
+
+    #[test]
+    fn test_extract_video_id_short_url() {
+        assert_eq!(
+            extract_video_id("https://youtu.be/1mzl2Oo8Ncw").unwrap(),
+            "1mzl2Oo8Ncw"
+        );
+    }
+
+    #[test]
+    fn test_extract_video_id_embed() {
+        assert_eq!(
+            extract_video_id("https://www.youtube.com/embed/1mzl2Oo8Ncw").unwrap(),
+            "1mzl2Oo8Ncw"
+        );
+    }
+
+    #[test]
+    fn test_extract_video_id_shorts() {
+        assert_eq!(
+            extract_video_id("https://www.youtube.com/shorts/1mzl2Oo8Ncw").unwrap(),
+            "1mzl2Oo8Ncw"
+        );
+    }
+
+    #[test]
+    fn test_extract_video_id_with_params() {
+        assert_eq!(
+            extract_video_id("https://www.youtube.com/watch?v=1mzl2Oo8Ncw&t=120").unwrap(),
+            "1mzl2Oo8Ncw"
+        );
+    }
+
+    #[test]
+    fn test_is_youtube_url() {
+        assert!(is_youtube_url("https://www.youtube.com/watch?v=abc"));
+        assert!(is_youtube_url("https://youtu.be/abc"));
+        assert!(!is_youtube_url("https://example.com/file.zip"));
+    }
+
+    #[test]
+    fn test_sanitize_filename() {
+        assert_eq!(sanitize_filename("Hello: World?"), "Hello_ World_");
+        assert_eq!(sanitize_filename("Normal Title"), "Normal Title");
+    }
+
+    #[test]
+    fn test_extract_json_object() {
+        assert_eq!(extract_json_object(r#"{"a":1};"#), Some(r#"{"a":1}"#));
+        assert_eq!(
+            extract_json_object(r#"{"a":{"b":2}}rest"#),
+            Some(r#"{"a":{"b":2}}"#)
+        );
+        assert_eq!(
+            extract_json_object(r#"{"s":"he said \"hi\""}x"#),
+            Some(r#"{"s":"he said \"hi\""}"#)
+        );
+    }
+}

--- a/docs/plan-youtube-hls-dash.md
+++ b/docs/plan-youtube-hls-dash.md
@@ -1,0 +1,212 @@
+# Plan: YouTube + HLS/DASH Streaming Support
+
+## Context
+
+YouTube-Downloads funktionieren nicht, weil der aktuelle `ANDROID` innertube-Client keine direkten URLs mehr liefert. Außerdem fehlen HLS- und DASH-Downloader komplett — ohne die kann amigo-dl keine Streaming-Formate laden. Die YouTube-Logik liegt aktuell falsch im Core-Crate statt in einem eigenen Extractor.
+
+**Ziel:** YouTube-Downloads zum Laufen bringen, HLS/DASH als Protokolle unterstützen, YouTube aus Core rausnehmen, `--verbose` Flag fürs Debugging.
+
+---
+
+## Architektur-Entscheidungen
+
+### YouTube → neues `crates/extractors/` Crate
+- YouTube ist site-spezifisch, nicht Core-Protokoll
+- Extractors transformieren Page-URLs in downloadbare Stream-URLs
+- Server-Crate kann es später auch nutzen (kein Duplizieren)
+- Pattern für weitere Sites (Twitch, Vimeo) erweiterbar
+
+### HLS/DASH → `crates/core/src/protocol/`
+- Sind Transport-Protokolle wie HTTP/NNTP → gehören zu Core
+- Jeder Extractor/Plugin der eine m3u8/mpd URL liefert kann sie nutzen
+
+### N-Parameter → `rquickjs` (embedded QuickJS)
+- Ohne N-Parameter-Lösung: YouTube throttled auf ~50KB/s
+- `rquickjs` ist ein embedded JS-Runtime (~2MB Binärgröße)
+- Kompiliert QuickJS aus C-Source, läuft auf Windows mit MSVC
+- JS-Ausführung ist schnell (<50ms), via `spawn_blocking`
+
+### YouTube-Client → `android_vr` (Oculus Quest 3)
+- Liefert direkte URLs ohne PO-Tokens oder Signature-Decryption
+- clientName: `ANDROID_VR`, clientVersion: `1.65.10`
+- deviceMake: Oculus, deviceModel: Quest 3, androidSdkVersion: 32
+- userAgent: `com.google.android.apps.youtube.vr.oculus/1.65.10 (Linux; U; Android 12L; eureka-user Build/SQ3A.220605.009.A1) gzip`
+- Limitierung: "Made for kids" Videos gehen nicht → Fallback auf `web_embedded`
+
+---
+
+## Umsetzung in 8 Phasen
+
+### Phase 0: Branch + Scaffolding
+1. Branch `feat/youtube-hls-dash` erstellen
+2. `crates/extractors/` mit `Cargo.toml` + `src/lib.rs` anlegen
+3. Workspace-Root: `amigo-extractors` registrieren
+4. CLI: `amigo-extractors` als Dependency
+5. `cargo check` verifizieren
+
+### Phase 1: YouTube aus Core rausnehmen
+6. `crates/core/src/protocol/youtube.rs` → `crates/extractors/src/youtube/` verschieben + aufteilen:
+   - `url_parser.rs` — Video-ID Extraktion
+   - `innertube.rs` — API-Client
+   - `formats.rs` — Format-Parsing, Qualitäts-Auswahl
+   - `mod.rs` — Public API
+7. `Extractor` Trait + `ExtractedMedia` Types in `crates/extractors/src/`
+8. CLI updaten: `amigo_extractors` statt `amigo_core::protocol::youtube`
+9. `pub mod youtube;` aus `crates/core/src/protocol/mod.rs` entfernen
+10. Tests migrieren, `cargo test` verifizieren
+
+### Phase 2: YouTube-Extraktion fixen (`android_vr`)
+11. `innertube.rs` umschreiben auf `android_vr` Client-Config
+12. Korrekter User-Agent + Headers (`X-YouTube-Client-Name: 28`)
+13. Fallback: `web_embedded` (clientName `WEB_EMBEDDED_PLAYER`, clientVersion `1.20260115.01.00`, embedUrl `https://www.reddit.com/`)
+14. Watch-Page Fallback beibehalten
+15. Testen mit `--verbose`
+
+### Phase 3: `--verbose` Flag
+16. `-v/--verbose` Flag zum `Cli` Struct
+17. `tracing_subscriber` Init am Anfang von `main()`
+18. Default: `warn`, verbose: `debug`, `RUST_LOG` env hat Vorrang
+
+### Phase 4: N-Parameter Challenge
+19. `rquickjs` zu Workspace + Extractors Dependencies
+20. `n_challenge.rs`: Player-JS fetchen, N-Funktion extrahieren, via QuickJS ausführen
+21. In-Memory Cache für Player-JS (nach URL gekeys)
+22. N-Parameter in allen Stream-URLs transformieren
+23. Testen: Download-Speed >1 MB/s verifizieren
+
+### Phase 5: HLS Downloader
+24. `m3u8-rs` zu Workspace + Core Dependencies
+25. `crates/core/src/protocol/hls.rs` erstellen:
+    - Master-Playlist parsen → beste Variante wählen
+    - Media-Playlist parsen → Segment-URLs sammeln
+    - Parallele Segment-Downloads (8 concurrent)
+    - Segments zusammenfügen (Concatenation)
+    - Progress-Reporting via `watch::Sender<DownloadProgress>`
+26. `Protocol::Hls` zum Enum, `pub mod hls;` registrieren
+27. CLI: HLS-Dispatch in `direct_download()`
+
+### Phase 6: DASH Downloader
+28. `dash-mpd` zu Workspace + Core Dependencies
+29. `crates/core/src/protocol/dash.rs` erstellen:
+    - MPD parsen, beste Representation wählen
+    - Segment-URLs generieren (SegmentTemplate mit `$Number$`)
+    - Parallele Segment-Downloads
+    - Reassembly (Init-Segment + Media-Segments)
+30. `Protocol::Dash` zum Enum, `pub mod dash;` registrieren
+31. CLI: DASH-Dispatch in `direct_download()`
+
+### Phase 7: Integration
+32. Coordinator updaten für HLS/DASH in `start_download()`
+33. `detect_protocol()` für `.m3u8` und `.mpd` URLs erweitern
+34. `ResolvedUrl` Struct um `protocol` Feld erweitern
+
+### Phase 8: Tests + Polish
+35. Unit-Tests: HLS-Manifest-Parsing, DASH-Manifest-Parsing, YouTube URL-Parsing
+36. Integration-Test: YouTube Full-Flow (`#[ignore]`, braucht Netzwerk)
+37. `cargo clippy`, `cargo fmt`
+
+---
+
+## Dateien
+
+### Neu erstellen
+```
+crates/extractors/Cargo.toml
+crates/extractors/src/lib.rs
+crates/extractors/src/error.rs
+crates/extractors/src/traits.rs
+crates/extractors/src/youtube/mod.rs
+crates/extractors/src/youtube/innertube.rs
+crates/extractors/src/youtube/url_parser.rs
+crates/extractors/src/youtube/formats.rs
+crates/extractors/src/youtube/n_challenge.rs
+crates/core/src/protocol/hls.rs
+crates/core/src/protocol/dash.rs
+```
+
+### Modifizieren
+```
+Cargo.toml                              — workspace members + deps (rquickjs, m3u8-rs, dash-mpd)
+crates/core/Cargo.toml                  — m3u8-rs, dash-mpd
+crates/core/src/protocol/mod.rs         — youtube entfernen, hls/dash hinzu, Protocol enum
+crates/core/src/coordinator.rs          — HLS/DASH dispatch
+crates/cli/Cargo.toml                   — amigo-extractors dep
+crates/cli/src/main.rs                  — verbose flag, extractor integration, protocol dispatch
+```
+
+### Löschen
+```
+crates/core/src/protocol/youtube.rs     — verschoben nach extractors
+```
+
+---
+
+## Neue Dependencies
+
+| Crate | Version | Zweck |
+|-------|---------|-------|
+| `rquickjs` | 0.9 | JS-Runtime für N-Parameter Challenge |
+| `m3u8-rs` | 6 | HLS Manifest Parsing |
+| `dash-mpd` | 0.17 | DASH/MPD Manifest Parsing |
+
+---
+
+## Key Types
+
+```rust
+// crates/extractors/src/lib.rs
+pub struct ExtractedMedia {
+    pub title: String,
+    pub streams: Vec<MediaStream>,
+}
+
+pub struct MediaStream {
+    pub url: String,
+    pub protocol: StreamProtocol,
+    pub quality_label: String,
+    pub height: u32,
+    pub mime_type: String,
+    pub filesize: Option<u64>,
+    pub has_audio: bool,
+    pub has_video: bool,
+}
+
+pub enum StreamProtocol { Http, Hls, Dash }
+```
+
+---
+
+## Verifizierung
+
+1. `cargo test --workspace` — alle Tests grün
+2. `cargo clippy --workspace` — keine Warnings
+3. `amigo-dl --verbose https://www.youtube.com/watch?v=1mzl2Oo8Ncw` — zeigt Debug-Output, lädt Video runter
+4. `amigo-dl https://example.com/file.zip` — normaler HTTP-Download funktioniert weiterhin
+5. Download-Speed >1 MB/s (N-Parameter korrekt gelöst)
+
+---
+
+## Risiken
+
+- **`rquickjs` Build auf Windows**: Braucht MSVC C-Compiler (normalerweise mit Rust-Toolchain vorhanden). Früh in Phase 4 testen.
+- **YouTube API-Änderungen**: Client-Config als Daten strukturieren, nicht in Logik hardcoden → einfach austauschbar.
+- **Audio/Video Muxing**: `android_vr` liefert Combined-Formats bis 720p. Für höhere Qualitäten braucht es separate Streams + Muxing (späteres Feature).
+
+---
+
+## yt-dlp Referenz
+
+Basierend auf Analyse von `yt-dlp/yt_dlp/extractor/youtube/` und `yt-dlp/yt_dlp/downloader/`:
+
+### Innertube Client-Priorität (yt-dlp)
+1. `android_vr` — kein PO-Token, kein Signature-Decryption, kein JS-Player nötig
+2. `web_embedded` — kein PO-Token, braucht aber JS-Player für Signature
+3. `web_safari` — PO-Token nötig, liefert HLS-Formate
+4. `tv` — kein PO-Token, braucht JS-Player
+
+### Downloader in yt-dlp
+- **HttpFD** — Standard HTTP mit Resume
+- **HlsFD** — m3u8 Manifest, AES-128 Decryption, Segment-Downloads
+- **DashSegmentsFD** — MPD Manifest, Fragment-Downloads, Resume
+- **FFmpegFD** — Fallback über FFmpeg
+- Plus: RTMP, F4M, ISM, RTSP, WebSocket, etc. (für YouTube irrelevant)

--- a/plugins/hosters/youtube.rn
+++ b/plugins/hosters/youtube.rn
@@ -1,0 +1,162 @@
+// YouTube plugin for amigo-downloader
+//
+// Resolves YouTube watch/short/embed URLs to direct stream URLs
+// via the innertube player API.
+//
+// Note: This plugin requires the Rune Host API bridge (http_post, json_parse).
+// Until the bridge is wired, the native Rust implementation in
+// core/src/protocol/youtube.rs handles YouTube downloads.
+
+pub fn plugin_id() { "youtube" }
+pub fn plugin_name() { "YouTube" }
+pub fn plugin_version() { "1.0.0" }
+pub fn plugin_description() { "Download videos from YouTube" }
+pub fn plugin_author() { "amigo-labs" }
+pub fn url_pattern() { r"https?://(www\.)?(youtube\.com/(watch|shorts|embed)|youtu\.be/)" }
+
+pub async fn resolve(url) {
+    let video_id = extract_video_id(url);
+    if video_id == None {
+        return Err("Could not extract video ID from URL");
+    }
+    let video_id = video_id.unwrap();
+
+    log_info(`Resolving YouTube video: ${video_id}`);
+
+    // Call innertube API with Android client context
+    let body = `{
+        "videoId": "${video_id}",
+        "context": {
+            "client": {
+                "clientName": "ANDROID",
+                "clientVersion": "19.09.37",
+                "androidSdkVersion": 30,
+                "hl": "en",
+                "gl": "US"
+            }
+        }
+    }`;
+
+    let resp = http_post(
+        "https://www.youtube.com/youtubei/v1/player?prettyPrint=false",
+        body,
+        "application/json",
+    ).await?;
+
+    if resp.0 != 200 {
+        return Err(`YouTube API returned status ${resp.0}`);
+    }
+
+    let data = json_parse(resp.1)?;
+
+    let title = data["videoDetails"]["title"];
+    if title == None {
+        return Err("Could not get video title");
+    }
+
+    // Find best combined format (audio + video) with direct URL
+    let formats = data["streamingData"]["formats"];
+    let best_url = None;
+    let best_quality = "";
+    let best_height = 0;
+    let best_size = None;
+    let best_mime = "video/mp4";
+
+    if formats != None {
+        for fmt in formats {
+            if fmt["url"] != None {
+                let height = fmt["height"];
+                if height != None && height > best_height {
+                    best_url = Some(fmt["url"]);
+                    best_height = height;
+                    best_quality = fmt["qualityLabel"];
+                    best_size = fmt["contentLength"];
+                    best_mime = fmt["mimeType"];
+                }
+            }
+        }
+    }
+
+    // Fallback to adaptive formats (video-only)
+    if best_url == None {
+        let adaptive = data["streamingData"]["adaptiveFormats"];
+        if adaptive != None {
+            for fmt in adaptive {
+                if fmt["url"] != None && fmt["mimeType"] != None {
+                    let mime = fmt["mimeType"];
+                    if mime.starts_with("video/") {
+                        let height = fmt["height"];
+                        if height != None && height > best_height {
+                            best_url = Some(fmt["url"]);
+                            best_height = height;
+                            best_quality = fmt["qualityLabel"];
+                            best_size = fmt["contentLength"];
+                            best_mime = mime;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if best_url == None {
+        let reason = data["playabilityStatus"]["reason"];
+        if reason != None {
+            return Err(`YouTube: ${reason}`);
+        }
+        return Err("No downloadable streams found");
+    }
+
+    let ext = if best_mime.starts_with("video/webm") { "webm" } else { "mp4" };
+    let filename = `${title}.${ext}`;
+
+    log_info(`Selected: ${best_quality} (${best_mime})`);
+
+    Ok(#{
+        url: best_url.unwrap(),
+        filename: filename,
+        filesize: best_size,
+        chunks_supported: false,
+        max_chunks: None,
+        headers: None,
+        cookies: None,
+        wait_seconds: None,
+        mirrors: [],
+    })
+}
+
+pub async fn check_online(url) {
+    let video_id = extract_video_id(url);
+    if video_id == None {
+        return Ok("unknown");
+    }
+
+    let resp = http_get(
+        `https://www.youtube.com/oembed?url=https://www.youtube.com/watch?v=${video_id.unwrap()}&format=json`,
+        None,
+    ).await?;
+
+    if resp.0 == 200 {
+        Ok("online")
+    } else if resp.0 == 404 || resp.0 == 401 {
+        Ok("offline")
+    } else {
+        Ok("unknown")
+    }
+}
+
+fn extract_video_id(url) {
+    // youtube.com/watch?v=ID
+    let m = regex_match(r"[?&]v=([a-zA-Z0-9_-]{11})", url);
+    if m != None { return m; }
+
+    // youtu.be/ID
+    let m = regex_match(r"youtu\.be/([a-zA-Z0-9_-]{11})", url);
+    if m != None { return m; }
+
+    // /embed/ID or /shorts/ID
+    let m = regex_match(r"/(embed|shorts|v)/([a-zA-Z0-9_-]{11})", url);
+    if m != None { return m; }
+
+    None
+}


### PR DESCRIPTION
…ionality

- Updated the binary name from "amigo" to "amigo-dl" in Cargo.toml.
- Added support for direct downloads via command line arguments, allowing users to specify URLs, output directories, and chunk counts.
- Implemented progress reporting for downloads using the indicatif crate.
- Resolved YouTube URLs using the innertube API, extracting video details and stream URLs.
- Created a new module for YouTube protocol handling, including video ID extraction and format parsing.
- Added a new plan document for future YouTube HLS/DASH streaming support.
- Introduced a YouTube plugin for the amigo-downloader, enabling integration with the Rune Host API.