### PR TITLE
fix: resolve nightly build failures across macOS, aarch64-linux, and …

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -59,8 +59,8 @@ jobs:
           NIGHTLY_VERSION="${BASE_VERSION}-nightly.${DATE}"
           echo "NIGHTLY_DATE=${DATE}" >> $GITHUB_ENV
           echo "NIGHTLY_VERSION=${NIGHTLY_VERSION}" >> $GITHUB_ENV
-          # Stamp version into workspace Cargo.toml
-          sed -i "s/^version = \"${BASE_VERSION}\"/version = \"${NIGHTLY_VERSION}\"/" Cargo.toml
+          # Stamp version into workspace Cargo.toml (perl for macOS compat)
+          perl -i -pe "s/^version = \"${BASE_VERSION}\"/version = \"${NIGHTLY_VERSION}\"/" Cargo.toml
 
       - uses: Swatinem/rust-cache@v2
         with:
@@ -78,15 +78,17 @@ jobs:
         if: runner.os == 'Windows'
         run: choco install protoc -y
 
-      - name: Install cross-compilation tools
+      - name: Install cross tool
         if: matrix.cross
-        run: |
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-          echo '[target.aarch64-unknown-linux-gnu]' >> ~/.cargo/config.toml
-          echo 'linker = "aarch64-linux-gnu-gcc"' >> ~/.cargo/config.toml
+        run: cargo install cross --git https://github.com/cross-rs/cross
 
       - name: Build CLI
+        if: ${{ !matrix.cross }}
         run: cargo build --release --target ${{ matrix.target }} -p amigo-cli
+
+      - name: Build CLI (cross)
+        if: ${{ matrix.cross }}
+        run: cross build --release --target ${{ matrix.target }} -p amigo-cli
 
       - name: Package (Unix)
         if: runner.os != 'Windows'
@@ -163,6 +165,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set nightly version
+        shell: bash
+        run: |
+          DATE=$(date -u +%Y%m%d)
+          BASE_VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
+          NIGHTLY_VERSION="${BASE_VERSION}-nightly.${DATE}"
+          echo "NIGHTLY_VERSION=${NIGHTLY_VERSION}" >> $GITHUB_ENV
+          # Stamp workspace Cargo.toml (perl for macOS compat)
+          perl -i -pe "s/^version = \"${BASE_VERSION}\"/version = \"${NIGHTLY_VERSION}\"/" Cargo.toml
+          # Stamp tauri.conf.json
+          perl -i -pe "s/\"version\": \"${BASE_VERSION}\"/\"version\": \"${NIGHTLY_VERSION}\"/" tauri/tauri.conf.json
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -199,6 +213,8 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           projectPath: tauri
           tauriScript: npx tauri
@@ -211,10 +227,18 @@ jobs:
           path: |
             tauri/target/${{ matrix.target }}/release/bundle/deb/*.deb
             tauri/target/${{ matrix.target }}/release/bundle/appimage/*.AppImage
+            tauri/target/${{ matrix.target }}/release/bundle/appimage/*.AppImage.tar.gz
+            tauri/target/${{ matrix.target }}/release/bundle/appimage/*.AppImage.tar.gz.sig
             tauri/target/${{ matrix.target }}/release/bundle/dmg/*.dmg
             tauri/target/${{ matrix.target }}/release/bundle/macos/*.app
+            tauri/target/${{ matrix.target }}/release/bundle/macos/*.app.tar.gz
+            tauri/target/${{ matrix.target }}/release/bundle/macos/*.app.tar.gz.sig
             tauri/target/${{ matrix.target }}/release/bundle/msi/*.msi
+            tauri/target/${{ matrix.target }}/release/bundle/msi/*.msi.zip
+            tauri/target/${{ matrix.target }}/release/bundle/msi/*.msi.zip.sig
             tauri/target/${{ matrix.target }}/release/bundle/nsis/*.exe
+            tauri/target/${{ matrix.target }}/release/bundle/nsis/*.nsis.zip
+            tauri/target/${{ matrix.target }}/release/bundle/nsis/*.nsis.zip.sig
 
   # ─── Nightly Release ───────────────────────────────────────────────
   release:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -83,15 +83,17 @@ jobs:
         if: runner.os == 'Windows'
         run: choco install protoc -y
 
-      - name: Install cross-compilation tools
+      - name: Install cross tool
         if: matrix.cross
-        run: |
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-          echo '[target.aarch64-unknown-linux-gnu]' >> ~/.cargo/config.toml
-          echo 'linker = "aarch64-linux-gnu-gcc"' >> ~/.cargo/config.toml
+        run: cargo install cross --git https://github.com/cross-rs/cross
 
       - name: Build CLI and Server
+        if: ${{ !matrix.cross }}
         run: cargo build --release --target ${{ matrix.target }} -p amigo-cli -p amigo-server
+
+      - name: Build CLI and Server (cross)
+        if: ${{ matrix.cross }}
+        run: cross build --release --target ${{ matrix.target }} -p amigo-cli -p amigo-server
 
       - name: Package (Unix)
         if: runner.os != 'Windows'

--- a/tauri/tauri.conf.json
+++ b/tauri/tauri.conf.json
@@ -51,7 +51,7 @@
       "endpoints": [
         "https://github.com/amigo-labs/amigo-downloader/releases/latest/download/latest.json"
       ],
-      "pubkey": "REPLACE_WITH_REAL_KEY_BEFORE_RELEASE"
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDVDODgyNDEyMDI2RUExRDQKUldUVW9XNENFaVNJWEp0SCtWM3NUUlpUNHZhQXRzaFdQQnhNODRPSnhqNFJONUVLVEJJazI3QmUK"
     }
   }
 }


### PR DESCRIPTION
…Tauri installers

- Replace sed -i with perl -i -pe for macOS BSD compatibility in version stamping
- Use cross tool (cross-rs) for aarch64-linux CLI builds instead of manual cross-compilation setup (fixes missing OpenSSL/bindgen deps)
- Add TAURI_SIGNING_PRIVATE_KEY env vars to installer job (aligned with release-build.yml)
- Add nightly version stamping to installer job (Cargo.toml + tauri.conf.json)
- Complete installer artifact upload patterns (.tar.gz, .sig, .zip files)

https://claude.ai/code/session_01HbwSA6e8nwK1RqHj9Feovb