### PR TITLE
Security audit fixes: supply-chain, sandbox limits, SSRF, data loss

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,17 @@ env:
   RUSTFLAGS: "-D warnings"
 
 jobs:
+  rust-fmt:
+    name: Rust (rustfmt)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - name: Format check
+        run: cargo fmt --all -- --check
+
   rust:
     name: Rust (clippy, test)
     runs-on: ubuntu-latest
@@ -37,6 +48,39 @@ jobs:
 
       - name: Test
         run: cargo test --workspace --exclude amigo-desktop --locked
+
+  cargo-audit:
+    name: Cargo audit (known vulnerabilities)
+    runs-on: ubuntu-latest
+    # Don't gate the merge on audit alerts — advisories land mid-week and
+    # we don't want to block unrelated PRs. Continue-on-error keeps the
+    # signal visible without making the job a hard requirement.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install cargo-audit
+        run: cargo install --locked cargo-audit
+      - name: Run cargo audit
+        run: cargo audit --deny warnings
+
+  pnpm-audit:
+    name: pnpm audit (npm advisories)
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.33.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: pnpm audit (moderate+)
+        run: pnpm audit --audit-level moderate
 
   web-ui:
     name: Web UI (build + check)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,6 +212,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "subtle",
  "tempfile",
  "tokio",
  "tower",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,11 +214,13 @@ dependencies = [
  "sha2",
  "subtle",
  "tempfile",
+ "thiserror 2.0.18",
  "tokio",
  "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",
+ "url",
  "uuid",
 ]
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -10,10 +10,10 @@ use tracing::debug;
 use amigo_core::bandwidth::{BandwidthConfig, BandwidthLimiter};
 use amigo_core::config::Config;
 use amigo_core::coordinator::Coordinator;
-use amigo_core::protocol::{DownloadJob, Protocol, ProtocolBackend};
 use amigo_core::protocol::dash::DashDownloader;
 use amigo_core::protocol::hls::HlsDownloader;
 use amigo_core::protocol::http::{DownloadProgress, HttpDownloader};
+use amigo_core::protocol::{DownloadJob, Protocol, ProtocolBackend};
 use amigo_core::queue::QueueStatus;
 use amigo_core::storage::Storage;
 use amigo_plugin_runtime::loader::PluginLoader;
@@ -232,10 +232,7 @@ fn print_banner(mode: OutputMode) {
         style("amigo-dl").bold().cyan(),
         style(format!("v{}", amigo_core::updater::CURRENT_VERSION)).dim()
     );
-    eprintln!(
-        "  {}",
-        style("Fast, modular download manager").dim()
-    );
+    eprintln!("  {}", style("Fast, modular download manager").dim());
     eprintln!();
 }
 
@@ -253,7 +250,9 @@ impl Tui {
     /// Print a success message.
     fn success(&self, msg: &str) {
         match self.mode {
-            OutputMode::Fancy => eprintln!("  {} {}", style("✔").green().bold(), style(msg).green()),
+            OutputMode::Fancy => {
+                eprintln!("  {} {}", style("✔").green().bold(), style(msg).green())
+            }
             OutputMode::Plain => println!("OK: {msg}"),
             OutputMode::Json => {} // JSON mode uses structured output
         }
@@ -314,7 +313,10 @@ impl Tui {
     /// Output pretty JSON (only in JSON mode).
     fn json_pretty(&self, value: &serde_json::Value) {
         if self.mode == OutputMode::Json {
-            println!("{}", serde_json::to_string_pretty(value).unwrap_or_default());
+            println!(
+                "{}",
+                serde_json::to_string_pretty(value).unwrap_or_default()
+            );
         }
     }
 
@@ -322,18 +324,17 @@ impl Tui {
     fn progress_style(&self) -> ProgressStyle {
         match self.mode {
             OutputMode::Fancy => ProgressStyle::with_template(
-                "  {spinner:.cyan} [{bar:35.cyan/dim}] {bytes}/{total_bytes} {wide_msg}"
+                "  {spinner:.cyan} [{bar:35.cyan/dim}] {bytes}/{total_bytes} {wide_msg}",
             )
             .unwrap()
             .progress_chars("━╸─")
             .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏", "✔"]),
-            OutputMode::Plain => ProgressStyle::with_template(
-                "  [{bar:30}] {bytes}/{total_bytes} {msg}"
-            )
-            .unwrap()
-            .progress_chars("#>-"),
-            OutputMode::Json => ProgressStyle::with_template("")
-                .unwrap(),
+            OutputMode::Plain => {
+                ProgressStyle::with_template("  [{bar:30}] {bytes}/{total_bytes} {msg}")
+                    .unwrap()
+                    .progress_chars("#>-")
+            }
+            OutputMode::Json => ProgressStyle::with_template("").unwrap(),
         }
     }
 
@@ -374,11 +375,19 @@ impl Tui {
                     "dash" => "📡",
                     _ => "⬇",
                 };
-                eprintln!("  {} {} {}", style(icon).cyan(), style(protocol.to_uppercase()).bold().cyan(), style(url).dim());
+                eprintln!(
+                    "  {} {} {}",
+                    style(icon).cyan(),
+                    style(protocol.to_uppercase()).bold().cyan(),
+                    style(url).dim()
+                );
             }
             OutputMode::Plain => println!("[{protocol}] {url}"),
             OutputMode::Json => {
-                println!("{}", serde_json::json!({"event": "start", "url": url, "protocol": protocol}));
+                println!(
+                    "{}",
+                    serde_json::json!({"event": "start", "url": url, "protocol": protocol})
+                );
             }
         }
     }
@@ -448,7 +457,9 @@ async fn resolve_url(
     // Fall back to protocol detection + HEAD
     let path = url.split('?').next().unwrap_or(url);
     if path.ends_with(".m3u8") || path.ends_with(".m3u") {
-        let filename = filename_from_url(url).replace(".m3u8", ".ts").replace(".m3u", ".ts");
+        let filename = filename_from_url(url)
+            .replace(".m3u8", ".ts")
+            .replace(".m3u", ".ts");
         return Ok((url.to_string(), filename, None, Protocol::Hls));
     }
     if path.ends_with(".mpd") {
@@ -457,10 +468,21 @@ async fn resolve_url(
     }
 
     // Plain HTTP — HEAD request for filename/size
-    let http = HttpDownloader::new(user_agent, BandwidthLimiter::new(BandwidthConfig::default()));
+    let http = HttpDownloader::new(
+        user_agent,
+        BandwidthLimiter::new(BandwidthConfig::default()),
+    );
     let head = http.head(url).await?;
-    let filename = head.filename.clone().unwrap_or_else(|| filename_from_url(url));
-    Ok((url.to_string(), filename, head.content_length, Protocol::Http))
+    let filename = head
+        .filename
+        .clone()
+        .unwrap_or_else(|| filename_from_url(url));
+    Ok((
+        url.to_string(),
+        filename,
+        head.content_length,
+        Protocol::Http,
+    ))
 }
 
 /// Run a direct download using the ProtocolBackend trait (same path as server).
@@ -600,8 +622,11 @@ async fn run_direct_downloads(
     let plugin_loader = PluginLoader::new(PathBuf::from("plugins"), SandboxLimits::default())
         .unwrap_or_else(|e| {
             tracing::warn!("Failed to load plugin runtime: {e}");
-            PluginLoader::new(PathBuf::from("/etc/amigo/plugins"), SandboxLimits::default())
-                .expect("Failed to initialize plugin runtime")
+            PluginLoader::new(
+                PathBuf::from("/etc/amigo/plugins"),
+                SandboxLimits::default(),
+            )
+            .expect("Failed to initialize plugin runtime")
         });
     let discovered = plugin_loader.discover().await.unwrap_or_default();
     if !discovered.is_empty() {
@@ -780,14 +805,19 @@ async fn main() -> anyhow::Result<()> {
             } else {
                 match mode {
                     OutputMode::Json => {
-                        let list: Vec<_> = downloads.iter().map(|d| serde_json::json!({
-                            "id": d.id,
-                            "status": d.status,
-                            "url": d.url,
-                            "filename": d.filename,
-                            "filesize": d.filesize,
-                            "bytes_downloaded": d.bytes_downloaded,
-                        })).collect();
+                        let list: Vec<_> = downloads
+                            .iter()
+                            .map(|d| {
+                                serde_json::json!({
+                                    "id": d.id,
+                                    "status": d.status,
+                                    "url": d.url,
+                                    "filename": d.filename,
+                                    "filesize": d.filesize,
+                                    "bytes_downloaded": d.bytes_downloaded,
+                                })
+                            })
+                            .collect();
                         tui.json(&serde_json::json!({"downloads": list}));
                     }
                     OutputMode::Fancy => {
@@ -858,7 +888,9 @@ async fn main() -> anyhow::Result<()> {
             coord.cancel(&id).await?;
             match mode {
                 OutputMode::Json => tui.json(&serde_json::json!({"action": "cancelled", "id": id})),
-                OutputMode::Fancy => tui.step("🗑", &format!("Cancelled: {}", style(&id[..8]).dim())),
+                OutputMode::Fancy => {
+                    tui.step("🗑", &format!("Cancelled: {}", style(&id[..8]).dim()))
+                }
                 OutputMode::Plain => println!("Cancelled: {id}"),
             }
         }
@@ -877,11 +909,16 @@ async fn main() -> anyhow::Result<()> {
             } else {
                 match mode {
                     OutputMode::Json => {
-                        let list: Vec<_> = queued.iter().map(|d| serde_json::json!({
-                            "id": d.id,
-                            "url": d.url,
-                            "filename": d.filename,
-                        })).collect();
+                        let list: Vec<_> = queued
+                            .iter()
+                            .map(|d| {
+                                serde_json::json!({
+                                    "id": d.id,
+                                    "url": d.url,
+                                    "filename": d.filename,
+                                })
+                            })
+                            .collect();
                         tui.json(&serde_json::json!({"queue": list}));
                     }
                     OutputMode::Fancy => {
@@ -897,7 +934,12 @@ async fn main() -> anyhow::Result<()> {
                     }
                     OutputMode::Plain => {
                         for (i, d) in queued.iter().enumerate() {
-                            println!("{}. {} — {}", i + 1, d.filename.as_deref().unwrap_or(&d.url), d.id);
+                            println!(
+                                "{}. {} — {}",
+                                i + 1,
+                                d.filename.as_deref().unwrap_or(&d.url),
+                                d.id
+                            );
                         }
                     }
                 }
@@ -928,18 +970,33 @@ async fn main() -> anyhow::Result<()> {
                 }
                 OutputMode::Fancy => {
                     print_banner(mode);
-                    tui.step("📊", &format!(
-                        "Active: {}  Queued: {}  Completed: {}  Failed: {}",
-                        style(active).cyan().bold(),
-                        style(queued).yellow(),
-                        style(completed).green(),
-                        if failed > 0 { style(failed).red().bold().to_string() } else { style(failed).dim().to_string() },
-                    ));
-                    tui.step("🚀", &format!("Speed: {}", style(format!("{}/s", format_bytes(speed))).bold()));
+                    tui.step(
+                        "📊",
+                        &format!(
+                            "Active: {}  Queued: {}  Completed: {}  Failed: {}",
+                            style(active).cyan().bold(),
+                            style(queued).yellow(),
+                            style(completed).green(),
+                            if failed > 0 {
+                                style(failed).red().bold().to_string()
+                            } else {
+                                style(failed).dim().to_string()
+                            },
+                        ),
+                    );
+                    tui.step(
+                        "🚀",
+                        &format!(
+                            "Speed: {}",
+                            style(format!("{}/s", format_bytes(speed))).bold()
+                        ),
+                    );
                 }
                 OutputMode::Plain => {
                     println!("amigo-dl v{}", amigo_core::updater::CURRENT_VERSION);
-                    println!("Active: {active}  Queued: {queued}  Completed: {completed}  Failed: {failed}");
+                    println!(
+                        "Active: {active}  Queued: {queued}  Completed: {completed}  Failed: {failed}"
+                    );
                     println!("Speed: {} KB/s", speed / 1024);
                 }
             }
@@ -950,7 +1007,10 @@ async fn main() -> anyhow::Result<()> {
             let speed = coord.total_speed().await;
             match mode {
                 OutputMode::Json => tui.json(&serde_json::json!({"speed_bytes_per_sec": speed})),
-                OutputMode::Fancy => tui.step("🚀", &format!("{}", style(format!("{}/s", format_bytes(speed))).bold())),
+                OutputMode::Fancy => tui.step(
+                    "🚀",
+                    &format!("{}", style(format!("{}/s", format_bytes(speed))).bold()),
+                ),
                 OutputMode::Plain => println!("{} KB/s", speed / 1024),
             }
         }
@@ -1019,9 +1079,7 @@ async fn main() -> anyhow::Result<()> {
                 // (`extractors/`), and great-grandparent is the root (`plugins/`).
                 // We go up to the category level so discover finds the plugin dir.
                 let plugin_parent = path.parent().unwrap_or(std::path::Path::new("."));
-                let plugin_dir = plugin_parent
-                    .parent()
-                    .unwrap_or(plugin_parent);
+                let plugin_dir = plugin_parent.parent().unwrap_or(plugin_parent);
                 let loader = PluginLoader::new(plugin_dir.to_path_buf(), SandboxLimits::default())
                     .map_err(|e| anyhow::anyhow!("{e}"))?;
                 loader
@@ -1078,10 +1136,8 @@ async fn main() -> anyhow::Result<()> {
                                 }
                             }
                             println!();
-                            let mut summary = format!(
-                                "{} passed, {} failed",
-                                results.passed, results.failed
-                            );
+                            let mut summary =
+                                format!("{} passed, {} failed", results.passed, results.failed);
                             if results.skipped > 0 {
                                 summary.push_str(&format!(", {} skipped", results.skipped));
                             }
@@ -1192,7 +1248,11 @@ async fn main() -> anyhow::Result<()> {
                     tui.info("No remotes configured. Run `amigo-dl login <url>`.");
                 } else {
                     for (alias, remote) in &r.remotes {
-                        let marker = if r.default.as_deref() == Some(alias) { "*" } else { " " };
+                        let marker = if r.default.as_deref() == Some(alias) {
+                            "*"
+                        } else {
+                            " "
+                        };
                         println!("{marker} {alias:<16} {}", remote.url);
                     }
                 }
@@ -1212,7 +1272,9 @@ async fn main() -> anyhow::Result<()> {
             RemoteAction::Use { name } => {
                 let mut r = remotes::load();
                 if !r.remotes.contains_key(&name) {
-                    tui.error(&format!("No remote named {name} — run `amigo-dl login` first."));
+                    tui.error(&format!(
+                        "No remote named {name} — run `amigo-dl login` first."
+                    ));
                 } else {
                     r.default = Some(name.clone());
                     remotes::save(&r).map_err(|e| anyhow::anyhow!(e))?;
@@ -1227,11 +1289,7 @@ async fn main() -> anyhow::Result<()> {
 
 /// Start a pairing request against `url`, poll until the admin approves/denies,
 /// and persist the resulting API token.
-async fn pair_with_remote(
-    url: &str,
-    name_override: Option<&str>,
-    tui: &Tui,
-) -> anyhow::Result<()> {
+async fn pair_with_remote(url: &str, name_override: Option<&str>, tui: &Tui) -> anyhow::Result<()> {
     let base = url.trim_end_matches('/').to_string();
     let hostname = std::env::var("HOSTNAME")
         .ok()
@@ -1328,12 +1386,14 @@ async fn pair_with_remote(
 
 fn hostname_fallback() -> Option<String> {
     // Portable "what's my hostname" without a crate: read /etc/hostname on unix.
-    std::fs::read_to_string("/etc/hostname")
-        .ok()
-        .and_then(|s| {
-            let t = s.trim();
-            if t.is_empty() { None } else { Some(t.to_string()) }
-        })
+    std::fs::read_to_string("/etc/hostname").ok().and_then(|s| {
+        let t = s.trim();
+        if t.is_empty() {
+            None
+        } else {
+            Some(t.to_string())
+        }
+    })
 }
 
 fn alias_from_url(url: &str) -> String {

--- a/crates/core/src/bandwidth.rs
+++ b/crates/core/src/bandwidth.rs
@@ -7,8 +7,7 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[derive(Default)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct BandwidthConfig {
     /// Global limit in bytes/s, 0 = unlimited.
     pub global_limit: u64,
@@ -34,7 +33,6 @@ pub struct BandwidthSchedule {
     /// Bandwidth limit during this period (bytes/s, 0 = unlimited).
     pub limit: u64,
 }
-
 
 /// Token-bucket based bandwidth limiter with time-based scheduling.
 #[derive(Clone)]

--- a/crates/core/src/captcha.rs
+++ b/crates/core/src/captcha.rs
@@ -137,9 +137,9 @@ impl CaptchaManager {
         match result {
             Ok(Ok(CaptchaAnswer::Solved(answer))) => {
                 debug!("Captcha solved: {captcha_id}");
-                let _ = self.event_tx.send(DownloadEvent::CaptchaSolved {
-                    id: captcha_id,
-                });
+                let _ = self
+                    .event_tx
+                    .send(DownloadEvent::CaptchaSolved { id: captcha_id });
                 Ok(answer)
             }
             Ok(Ok(CaptchaAnswer::Cancelled)) => {
@@ -153,9 +153,9 @@ impl CaptchaManager {
             }
             Err(_) => {
                 warn!("Captcha timed out: {captcha_id}");
-                let _ = self.event_tx.send(DownloadEvent::CaptchaTimeout {
-                    id: captcha_id,
-                });
+                let _ = self
+                    .event_tx
+                    .send(DownloadEvent::CaptchaTimeout { id: captcha_id });
                 Err(CaptchaError::Timeout(self.timeout.as_secs()))
             }
         }

--- a/crates/core/src/chunk.rs
+++ b/crates/core/src/chunk.rs
@@ -25,30 +25,136 @@ pub enum ChunkStatus {
 }
 
 impl ChunkPlan {
-    /// Split a file of `total_size` into `num_chunks` chunks.
+    /// Split a file of `total_size` into at most `num_chunks` chunks.
+    ///
+    /// When `total_size < num_chunks`, the previous implementation computed
+    /// `chunk_size = total_size / num_chunks = 0`, then derived
+    /// `end = start + 0 - 1` which wrapped to `u64::MAX`. The resulting
+    /// HTTP `Range` headers requested overlapping or absurd byte ranges
+    /// and the reassembly stage either looped or wrote garbage.
+    ///
+    /// Behaviour now:
+    ///  * `num_chunks == 0` or `total_size == 0` → empty plan.
+    ///  * The actual chunk count is capped at `total_size` so every chunk
+    ///    holds at least one byte.
+    ///  * `chunk_size = ceil(total_size / n)`, computed via `div_ceil` to
+    ///    avoid the underflow that bit the original code.
+    ///  * Each chunk's `end_byte` is clamped to `total_size - 1`.
+    ///  * For any `(total_size, num_chunks)`, the produced ranges cover
+    ///    `[0, total_size)` exactly once and remain disjoint.
     pub fn split(total_size: u64, num_chunks: u32) -> Self {
         if num_chunks == 0 || total_size == 0 {
             return Self { chunks: vec![] };
         }
-        let chunk_size = total_size / num_chunks as u64;
-        let mut chunks = Vec::with_capacity(num_chunks as usize);
+        // Cap requested chunks at total_size so chunk_size is always ≥ 1.
+        // After ceil-dividing, the *actual* number of populated chunks may
+        // still be smaller (e.g. total=100, requested=16 → chunk_size=7,
+        // only 15 chunks are needed — the 16th would start past EOF).
+        let requested = (num_chunks as u64).min(total_size);
+        let chunk_size = total_size.div_ceil(requested);
+        let mut chunks = Vec::with_capacity(requested as usize);
 
-        for i in 0..num_chunks {
-            let start = i as u64 * chunk_size;
-            let end = if i == num_chunks - 1 {
-                total_size - 1
-            } else {
-                start + chunk_size - 1
-            };
+        let mut start = 0u64;
+        let mut index: u32 = 0;
+        while start < total_size {
+            let end = start
+                .saturating_add(chunk_size)
+                .saturating_sub(1)
+                .min(total_size - 1);
             chunks.push(Chunk {
-                index: i,
+                index,
                 start_byte: start,
                 end_byte: end,
                 bytes_downloaded: 0,
                 status: ChunkStatus::Pending,
             });
+            // The next start cannot overflow because end < total_size and
+            // total_size <= u64::MAX.
+            start = end + 1;
+            index += 1;
         }
 
         Self { chunks }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_covers_exactly(plan: &ChunkPlan, total_size: u64) {
+        if total_size == 0 {
+            assert!(plan.chunks.is_empty());
+            return;
+        }
+        let mut expected = 0u64;
+        for c in &plan.chunks {
+            assert!(c.start_byte <= c.end_byte, "empty chunk: {c:?}");
+            assert_eq!(c.start_byte, expected, "gap or overlap at {c:?}");
+            expected = c
+                .end_byte
+                .checked_add(1)
+                .expect("end_byte must not be u64::MAX");
+        }
+        assert_eq!(expected, total_size, "plan does not cover the whole file");
+    }
+
+    #[test]
+    fn split_handles_total_smaller_than_num_chunks() {
+        // Regression: previously chunk_size = 10/100 = 0 and the non-last
+        // chunk's end wrapped to u64::MAX.
+        let plan = ChunkPlan::split(10, 100);
+        assert_eq!(plan.chunks.len(), 10, "chunks capped at total_size");
+        assert_covers_exactly(&plan, 10);
+        for c in &plan.chunks {
+            assert_eq!(c.end_byte - c.start_byte, 0, "each chunk is 1 byte");
+        }
+    }
+
+    #[test]
+    fn split_handles_perfect_division() {
+        let plan = ChunkPlan::split(1024, 4);
+        assert_eq!(plan.chunks.len(), 4);
+        assert_covers_exactly(&plan, 1024);
+        // 4 × 256 byte chunks
+        for c in &plan.chunks {
+            assert_eq!(c.end_byte - c.start_byte + 1, 256);
+        }
+    }
+
+    #[test]
+    fn split_handles_remainder() {
+        // 1000 / 7 → 143 with remainder; ceil(1000/7) = 143, last chunk is shorter.
+        let plan = ChunkPlan::split(1000, 7);
+        assert_eq!(plan.chunks.len(), 7);
+        assert_covers_exactly(&plan, 1000);
+    }
+
+    #[test]
+    fn split_handles_one_chunk() {
+        let plan = ChunkPlan::split(42, 1);
+        assert_eq!(plan.chunks.len(), 1);
+        assert_eq!(plan.chunks[0].start_byte, 0);
+        assert_eq!(plan.chunks[0].end_byte, 41);
+    }
+
+    #[test]
+    fn split_handles_zero_inputs() {
+        assert!(ChunkPlan::split(0, 4).chunks.is_empty());
+        assert!(ChunkPlan::split(100, 0).chunks.is_empty());
+    }
+
+    #[test]
+    fn split_property_random_inputs() {
+        // Ad-hoc property check (no proptest dependency): cover a spread
+        // of (total, n) combos and verify the invariant for each.
+        for total in [1u64, 2, 7, 100, 1_000, 1_234_567, u64::MAX / 2] {
+            for n in [1u32, 2, 3, 8, 16, 64, 1024] {
+                let plan = ChunkPlan::split(total, n);
+                assert_covers_exactly(&plan, total);
+                assert!(plan.chunks.len() <= n as usize);
+                assert!(plan.chunks.len() as u64 <= total);
+            }
+        }
     }
 }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -140,24 +140,20 @@ impl Default for ServerConfig {
 }
 
 /// NZBGet-compatible JSON-RPC API credentials for Sonarr/Radarr integration.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+///
+/// `enabled` defaults to `false` via `Default`, so a fresh install does not
+/// expose the JSON-RPC surface (which can queue/pause/delete downloads)
+/// before the operator turns it on and sets credentials.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct NzbGetApiConfig {
     /// Enable the NZBGet-compatible JSON-RPC API.
     pub enabled: bool,
-    /// Username for HTTP Basic Auth. Empty string disables auth.
+    /// Username for HTTP Basic Auth. Both fields must be non-empty when
+    /// `enabled` is true; the server refuses to start otherwise (see
+    /// `nzbget_api::validate_nzbget_config`).
     pub username: String,
-    /// Password for HTTP Basic Auth. Empty string disables auth.
+    /// Password for HTTP Basic Auth. Same non-empty requirement as `username`.
     pub password: String,
-}
-
-impl Default for NzbGetApiConfig {
-    fn default() -> Self {
-        Self {
-            enabled: true,
-            username: String::new(),
-            password: String::new(),
-        }
-    }
 }
 
 /// Retry behavior for failed downloads.

--- a/crates/core/src/container.rs
+++ b/crates/core/src/container.rs
@@ -174,18 +174,19 @@ fn parse_dlc_xml(xml: &str) -> Result<Vec<ContainerPackage>, crate::Error> {
 
             if let Some(url_b64) = extract_tag(file_content, "url")
                 && let Ok(url_bytes) = b64_decode(&url_b64)
-                    && let Ok(url) = String::from_utf8(url_bytes) {
-                        let filename = extract_tag(file_content, "filename")
-                            .and_then(|f| String::from_utf8(b64_decode(&f).ok()?).ok())
-                            .map(|f| crate::sanitize_filename(&f));
-                        let filesize =
-                            extract_tag(file_content, "size").and_then(|s| s.parse::<u64>().ok());
-                        links.push(ContainerLink {
-                            url,
-                            filename,
-                            filesize,
-                        });
-                    }
+                && let Ok(url) = String::from_utf8(url_bytes)
+            {
+                let filename = extract_tag(file_content, "filename")
+                    .and_then(|f| String::from_utf8(b64_decode(&f).ok()?).ok())
+                    .map(|f| crate::sanitize_filename(&f));
+                let filesize =
+                    extract_tag(file_content, "size").and_then(|s| s.parse::<u64>().ok());
+                links.push(ContainerLink {
+                    url,
+                    filename,
+                    filesize,
+                });
+            }
 
             fpos = file_end + 7;
         }

--- a/crates/core/src/coordinator.rs
+++ b/crates/core/src/coordinator.rs
@@ -92,10 +92,23 @@ pub struct Coordinator {
     queue_notify: Arc<tokio::sync::Notify>,
 }
 
+/// Capacity of the per-coordinator broadcast channel that fans
+/// `DownloadEvent`s out to every subscriber. Sized to absorb the bursts
+/// produced at startup recovery (50+ status changes in flight) and during
+/// large parallel-download progress fan-out.
+const EVENT_CHANNEL_CAPACITY: usize = 4096;
+
 impl Coordinator {
     pub fn new(config: Config, storage: Storage) -> Self {
         let bandwidth = BandwidthLimiter::new(config.bandwidth.clone());
-        let (event_tx, _) = broadcast::channel(256);
+        // Broadcast buffer holds DownloadEvent values for every subscriber
+        // (WebSocket clients, webhook dispatcher, plugin notifications, …).
+        // The previous capacity of 256 was easy to overflow at startup —
+        // recovering 50 downloads or running a webhook dispatcher with a
+        // slow receiver triggered Lagged() and dropped progress events. A
+        // larger buffer absorbs spiky bursts; subscribers that fall behind
+        // still see Lagged but with much more headroom.
+        let (event_tx, _) = broadcast::channel(EVENT_CHANNEL_CAPACITY);
 
         let retry_policy = RetryPolicy::from(config.retry.clone());
 
@@ -334,20 +347,23 @@ impl Coordinator {
         let queue_notify = self.queue_notify.clone();
 
         tokio::spawn(async move {
-            let mut original_progress_tx = Some(progress_tx);
+            // The progress watch channel lives across all retries. The
+            // forwarder spawned earlier reads `progress_rx`; if we created
+            // a fresh `(tx, _rx)` per retry the forwarder kept its old rx
+            // and the UI silently froze at "0%" through every retry. We
+            // clone the same sender into each attempt so every byte of
+            // progress flows through the original watch.
             let mut original_cancel_rx = Some(cancel_rx);
 
             let result = retry_with_policy(&retry_policy, |attempt| {
-                // Use the original progress_tx/cancel_rx on first attempt, create new ones for retries
-                let ptx = original_progress_tx.take().unwrap_or_else(|| {
-                    let (tx, _rx) = watch::channel(DownloadProgress {
-                        bytes_downloaded: 0,
-                        total_bytes: None,
-                        speed_bytes_per_sec: 0,
-                    });
-                    tx
-                });
+                let ptx = progress_tx.clone();
 
+                // The cancel channel is still a oneshot: cancel() consumes
+                // the sender so a second cancel is a no-op (intentional).
+                // After the first attempt that consumed `cancel_rx` the
+                // download cannot be cancelled mid-retry; that branch is
+                // tracked by audit #13 follow-up. Use a placeholder rx so
+                // retries don't block on cancel forever.
                 let crx = original_cancel_rx.take().unwrap_or_else(|| {
                     let (_tx, rx) = tokio::sync::oneshot::channel();
                     rx

--- a/crates/core/src/coordinator.rs
+++ b/crates/core/src/coordinator.rs
@@ -11,13 +11,13 @@ use uuid::Uuid;
 use crate::bandwidth::BandwidthLimiter;
 use crate::config::Config;
 use crate::postprocess;
-use crate::protocol::{Protocol, ResolvedDownload, UrlResolver};
-use crate::protocol::http::{DownloadProgress, HttpDownloader};
-use crate::protocol::hls::HlsDownloader;
 use crate::protocol::dash::DashDownloader;
-use crate::protocol::usenet::nntp::NntpServerConfig;
+use crate::protocol::hls::HlsDownloader;
+use crate::protocol::http::{DownloadProgress, HttpDownloader};
 use crate::protocol::usenet::UsenetConfig;
 use crate::protocol::usenet::UsenetDownloader;
+use crate::protocol::usenet::nntp::NntpServerConfig;
+use crate::protocol::{Protocol, ResolvedDownload, UrlResolver};
 use crate::queue::QueueStatus;
 use crate::retry::{RetryOutcome, RetryPolicy, retry_with_policy};
 use crate::storage::{DownloadRow, Storage};
@@ -171,7 +171,9 @@ impl Coordinator {
 
     /// Update the config at runtime and propagate to subsystems.
     pub async fn update_config(&self, new_config: Config) {
-        self.bandwidth.update_config(new_config.bandwidth.clone()).await;
+        self.bandwidth
+            .update_config(new_config.bandwidth.clone())
+            .await;
         *self.retry_policy.lock().await = RetryPolicy::from(new_config.retry.clone());
         *self.config.lock().await = new_config;
     }
@@ -409,11 +411,12 @@ impl Coordinator {
                         .await
                     } else {
                         // HTTP, HLS, DASH — use ProtocolBackend trait dispatch
-                        let backend: Box<dyn crate::protocol::ProtocolBackend> = match protocol.as_str() {
-                            "hls" => Box::new(HlsDownloader::new(user_agent, 8)),
-                            "dash" => Box::new(DashDownloader::new(user_agent, 8)),
-                            _ => Box::new(HttpDownloader::new(user_agent, bandwidth.clone())),
-                        };
+                        let backend: Box<dyn crate::protocol::ProtocolBackend> =
+                            match protocol.as_str() {
+                                "hls" => Box::new(HlsDownloader::new(user_agent, 8)),
+                                "dash" => Box::new(DashDownloader::new(user_agent, 8)),
+                                _ => Box::new(HttpDownloader::new(user_agent, bandwidth.clone())),
+                            };
                         backend.download(&job, ptx, crx).await
                     };
 
@@ -441,8 +444,7 @@ impl Coordinator {
                         if let Err(e) = postprocess::run_usenet_pipeline(dir, &pp_config).await {
                             warn!("Usenet post-processing failed for {download_id}: {e}");
                         }
-                    } else if let Err(e) =
-                        postprocess::run_pipeline(&actual_path, &pp_config).await
+                    } else if let Err(e) = postprocess::run_pipeline(&actual_path, &pp_config).await
                     {
                         warn!("Post-processing failed for {download_id}: {e}");
                     }

--- a/crates/core/src/i18n.rs
+++ b/crates/core/src/i18n.rs
@@ -92,9 +92,10 @@ pub fn available_locales(locales_dir: &std::path::Path) -> Vec<String> {
         for entry in entries.flatten() {
             let path = entry.path();
             if path.extension().is_some_and(|e| e == "json")
-                && let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
-                    locales.push(stem.to_string());
-                }
+                && let Some(stem) = path.file_stem().and_then(|s| s.to_str())
+            {
+                locales.push(stem.to_string());
+            }
         }
     }
     locales.sort();

--- a/crates/core/src/postprocess.rs
+++ b/crates/core/src/postprocess.rs
@@ -147,8 +147,9 @@ fn extract_zip(archive: &Path, output_dir: &Path) -> Result<(), crate::Error> {
 
         let name = entry.name().to_string();
 
-        // Zip Slip protection: reject traversal components and sanitize each
-        // path segment for platform-invalid characters (NUL, ':', etc.).
+        // Zip Slip protection (path components):
+        //   1. reject `..`, `.`, and empty segments after normalising `\`→`/`
+        //   2. sanitise each segment for NUL / `:` / control chars
         let sanitized = name
             .replace('\\', "/")
             .split('/')
@@ -168,6 +169,29 @@ fn extract_zip(archive: &Path, output_dir: &Path) -> Result<(), crate::Error> {
             continue;
         }
 
+        // Zip Slip protection (symlinks): refuse symlink entries entirely.
+        // The original guard only checked the *normalised* path; a symlink
+        // entry pointing at `..` followed by a regular entry under the same
+        // prefix would still escape the output dir at write time.
+        if is_symlink_entry(&entry) {
+            warn!(
+                "ZIP entry {:?} is a symlink — skipping (symlink-extraction disabled)",
+                name
+            );
+            continue;
+        }
+
+        // Defence in depth: if any intermediate component on disk is
+        // already a symlink (e.g. created by a previous corrupt extraction),
+        // refuse to write through it.
+        if has_symlink_ancestor(output_dir, &out_path)? {
+            warn!(
+                "ZIP entry {:?} would traverse a pre-existing symlink — skipping",
+                name
+            );
+            continue;
+        }
+
         if entry.is_dir() {
             std::fs::create_dir_all(&out_path)?;
         } else {
@@ -181,6 +205,39 @@ fn extract_zip(archive: &Path, output_dir: &Path) -> Result<(), crate::Error> {
     }
 
     Ok(())
+}
+
+/// True for ZIP entries whose Unix mode marks them as a symbolic link.
+/// On non-Unix platforms `unix_mode()` returns `None` and we fall back to
+/// `false` — Windows does not honour Unix symlink bits in zips, but the
+/// `has_symlink_ancestor` check still protects against real-on-disk
+/// symlinks.
+fn is_symlink_entry(entry: &zip::read::ZipFile<'_>) -> bool {
+    const S_IFMT: u32 = 0o170000;
+    const S_IFLNK: u32 = 0o120000;
+    matches!(entry.unix_mode(), Some(mode) if mode & S_IFMT == S_IFLNK)
+}
+
+/// Walk every component between `root` and `path` and return true if any
+/// already-existing component is a symlink. `path` itself is NOT checked
+/// because it doesn't exist yet at extraction time (and `File::create`
+/// O_CREAT|O_TRUNC will overwrite a symlink target — that is the very thing
+/// we want to refuse).
+fn has_symlink_ancestor(root: &Path, path: &Path) -> Result<bool, crate::Error> {
+    let mut cur = path.parent();
+    while let Some(p) = cur {
+        if p == root || !p.starts_with(root) {
+            break;
+        }
+        match std::fs::symlink_metadata(p) {
+            Ok(meta) if meta.file_type().is_symlink() => return Ok(true),
+            Ok(_) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => return Err(e.into()),
+        }
+        cur = p.parent();
+    }
+    Ok(false)
 }
 
 fn extract_7z(archive: &Path, output_dir: &Path) -> Result<(), crate::Error> {
@@ -424,6 +481,77 @@ fn run_external(cmd: &str, args: &[&str]) -> Result<(), crate::Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Build a zip in memory containing one symlink entry pointing at an
+    /// absolute path outside the output directory, plus a regular file.
+    /// Uses `ZipWriter::add_symlink` so the central-directory entry has
+    /// `external_attributes` flagged as S_IFLNK (the writer sets this
+    /// itself; `unix_permissions` alone is masked to 0o777).
+    #[cfg(unix)]
+    fn write_symlink_zip(dir: &Path) -> std::path::PathBuf {
+        use std::io::Write;
+        use zip::write::SimpleFileOptions;
+
+        let zip_path = dir.join("evil.zip");
+        let file = std::fs::File::create(&zip_path).unwrap();
+        let mut zw = zip::ZipWriter::new(file);
+
+        let opts = SimpleFileOptions::default();
+        zw.add_symlink("evil", "/tmp/should-not-exist-here", opts)
+            .unwrap();
+
+        zw.start_file("hello.txt", opts).unwrap();
+        zw.write_all(b"hi").unwrap();
+
+        zw.finish().unwrap();
+        zip_path
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn extract_zip_skips_symlink_entries() {
+        let dir = tempfile::tempdir().unwrap();
+        let zip_path = write_symlink_zip(dir.path());
+        let out = dir.path().join("out");
+        std::fs::create_dir_all(&out).unwrap();
+
+        extract_zip(&zip_path, &out).expect("extraction should not fail");
+
+        // The regular file extracted normally.
+        assert!(out.join("hello.txt").exists());
+        // The symlink entry was refused — `evil` must not exist as a
+        // symlink, regular file, or anything else.
+        let evil = out.join("evil");
+        assert!(
+            std::fs::symlink_metadata(&evil).is_err(),
+            "symlink entry must not have been created"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn has_symlink_ancestor_detects_pre_existing_link() {
+        // A previous corrupt extraction left a symlink in the output dir;
+        // a later well-formed entry that traverses through it must be
+        // refused.
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("real");
+        std::fs::create_dir_all(&target).unwrap();
+        let link = dir.path().join("through");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        let bad = link.join("payload.bin");
+        assert!(
+            has_symlink_ancestor(dir.path(), &bad).unwrap(),
+            "ancestor symlink must be detected"
+        );
+
+        let safe = dir.path().join("real").join("payload.bin");
+        assert!(
+            !has_symlink_ancestor(dir.path(), &safe).unwrap(),
+            "no symlink in this path"
+        );
+    }
 
     #[test]
     fn test_archive_type_detection() {

--- a/crates/core/src/postprocess.rs
+++ b/crates/core/src/postprocess.rs
@@ -137,8 +137,8 @@ fn extract_rar(archive: &Path, output_dir: &Path) -> Result<(), crate::Error> {
 
 fn extract_zip(archive: &Path, output_dir: &Path) -> Result<(), crate::Error> {
     let file = std::fs::File::open(archive)?;
-    let mut zip = zip::ZipArchive::new(file)
-        .map_err(|e| crate::Error::Other(format!("Invalid ZIP: {e}")))?;
+    let mut zip =
+        zip::ZipArchive::new(file).map_err(|e| crate::Error::Other(format!("Invalid ZIP: {e}")))?;
 
     for i in 0..zip.len() {
         let mut entry = zip
@@ -322,7 +322,10 @@ fn run_par2_phase(download_dir: &Path, config: &PostProcessConfig) -> Result<(),
         }
     } else {
         // Full mode: use all PAR2 files from the start (assumes all pre-downloaded)
-        info!("PAR2 verify+repair (full — all volumes loaded): {:?}", par2_file);
+        info!(
+            "PAR2 verify+repair (full — all volumes loaded): {:?}",
+            par2_file
+        );
 
         match run_external("par2", &["r", &par2_file.to_string_lossy()]) {
             Ok(()) => info!("PAR2 verify+repair complete"),
@@ -455,7 +458,9 @@ fn delete_rar_volumes(dir: &Path) {
                 .unwrap_or("")
                 .to_lowercase();
             // Delete .r00, .r01, .r02, ... (multipart rar volumes)
-            if ext.starts_with('r') && ext.len() >= 2 && ext[1..].chars().all(|c| c.is_ascii_digit())
+            if ext.starts_with('r')
+                && ext.len() >= 2
+                && ext[1..].chars().all(|c| c.is_ascii_digit())
             {
                 debug!("Deleting RAR volume: {:?}", entry.path());
                 let _ = std::fs::remove_file(entry.path());

--- a/crates/core/src/protocol/dash.rs
+++ b/crates/core/src/protocol/dash.rs
@@ -349,13 +349,14 @@ impl super::ProtocolBackend for DashDownloader {
         progress_tx: watch::Sender<DownloadProgress>,
         cancel_rx: tokio::sync::oneshot::Receiver<()>,
     ) -> Result<(u64, std::path::PathBuf), crate::Error> {
-        let fname = job
-            .filename
-            .clone()
-            .unwrap_or_else(|| {
-                job.url.rsplit('/').next().unwrap_or("stream").to_string()
-                    .replace(".mpd", ".mp4")
-            });
+        let fname = job.filename.clone().unwrap_or_else(|| {
+            job.url
+                .rsplit('/')
+                .next()
+                .unwrap_or("stream")
+                .to_string()
+                .replace(".mpd", ".mp4")
+        });
         let dest = job.download_dir.join(&fname);
         tokio::fs::create_dir_all(&job.download_dir).await?;
 

--- a/crates/core/src/protocol/hls.rs
+++ b/crates/core/src/protocol/hls.rs
@@ -215,14 +215,15 @@ impl super::ProtocolBackend for HlsDownloader {
         progress_tx: watch::Sender<DownloadProgress>,
         cancel_rx: tokio::sync::oneshot::Receiver<()>,
     ) -> Result<(u64, std::path::PathBuf), crate::Error> {
-        let fname = job
-            .filename
-            .clone()
-            .unwrap_or_else(|| {
-                job.url.rsplit('/').next().unwrap_or("stream").to_string()
-                    .replace(".m3u8", ".ts")
-                    .replace(".m3u", ".ts")
-            });
+        let fname = job.filename.clone().unwrap_or_else(|| {
+            job.url
+                .rsplit('/')
+                .next()
+                .unwrap_or("stream")
+                .to_string()
+                .replace(".m3u8", ".ts")
+                .replace(".m3u", ".ts")
+        });
         let dest = job.download_dir.join(&fname);
         tokio::fs::create_dir_all(&job.download_dir).await?;
 

--- a/crates/core/src/protocol/http.rs
+++ b/crates/core/src/protocol/http.rs
@@ -12,6 +12,30 @@ use tracing::{debug, info, warn};
 
 use crate::bandwidth::BandwidthLimiter;
 
+/// Flush kernel buffers and persist `file` to disk.
+///
+/// `flush().await` only drains the user-space buffer into the kernel; if the
+/// process crashes or power is lost between flush and the next OS-level
+/// fsync, the bytes can disappear and resume state in the database can no
+/// longer be reconciled with what's actually on disk. This helper wraps the
+/// `sync_all` invariant in one call site so every download path stays
+/// honest.
+async fn fsync_file(file: &mut tokio::fs::File) -> std::io::Result<()> {
+    file.flush().await?;
+    file.sync_all().await
+}
+
+/// Best-effort fsync of a directory so a preceding `rename` is durable on
+/// POSIX. Errors are swallowed because not every platform exposes directory
+/// fds (Windows is a no-op).
+async fn fsync_parent(path: &Path) {
+    if let Some(parent) = path.parent()
+        && let Ok(dir) = tokio::fs::File::open(parent).await
+    {
+        let _ = dir.sync_all().await;
+    }
+}
+
 /// Progress update for a download.
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct DownloadProgress {
@@ -106,7 +130,7 @@ impl HttpDownloader {
             }
         }
 
-        file.flush().await?;
+        fsync_file(&mut file).await?;
 
         let _ = progress_tx.send(DownloadProgress {
             bytes_downloaded: downloaded,
@@ -217,7 +241,7 @@ impl HttpDownloader {
                 dest_file.write_all(&chunk_data).await?;
                 tokio::fs::remove_file(&chunk_path).await?;
             }
-            dest_file.flush().await?;
+            fsync_file(&mut dest_file).await?;
             Ok(())
         }
         .await;
@@ -227,6 +251,10 @@ impl HttpDownloader {
             return Err(e);
         }
         tokio::fs::rename(&dest_tmp, dest).await?;
+        // Make the directory entry update durable. On POSIX an unflushed
+        // rename can vanish on crash even though the target file was
+        // sync_all'd before the rename; Windows treats this as a no-op.
+        fsync_parent(dest).await;
 
         let _ = progress_tx.send(DownloadProgress {
             bytes_downloaded: total_size,
@@ -308,7 +336,7 @@ impl HttpDownloader {
             }
         }
 
-        file.flush().await?;
+        fsync_file(&mut file).await?;
         info!("Resume download complete: {} bytes total", downloaded);
         Ok(downloaded)
     }
@@ -371,7 +399,9 @@ async fn download_chunk(
             .store(chunk_downloaded, std::sync::atomic::Ordering::Relaxed);
     }
 
-    file.flush().await?;
+    // Each chunk gets fsync'd so its bytes survive a crash before the
+    // reassembly stage reads it back.
+    fsync_file(&mut file).await?;
     debug!("Chunk {chunk_index} complete: {chunk_downloaded} bytes");
     Ok(())
 }
@@ -468,6 +498,32 @@ impl super::ProtocolBackend for HttpDownloader {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn fsync_file_persists_buffered_writes() {
+        // Sanity-check the helper used by every download path: bytes
+        // written through write_all + flush must survive a re-open. This is
+        // not a power-loss simulation, but it does catch a regression where
+        // the helper accidentally drops the sync_all step (e.g. someone
+        // reverting it back to flush()-only).
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("data.bin");
+        {
+            let mut f = tokio::fs::File::create(&path).await.unwrap();
+            f.write_all(b"hello-fsync").await.unwrap();
+            fsync_file(&mut f).await.unwrap();
+        }
+        let read_back = tokio::fs::read(&path).await.unwrap();
+        assert_eq!(read_back, b"hello-fsync");
+    }
+
+    #[tokio::test]
+    async fn fsync_parent_is_no_op_for_missing_dir() {
+        // The helper has to be a no-op (best-effort) on platforms or paths
+        // where the directory fd cannot be opened, so callers can use it
+        // unconditionally after a rename without sprinkling cfg(unix).
+        fsync_parent(std::path::Path::new("/nonexistent/never-created")).await;
+    }
 
     #[test]
     fn test_parse_content_disposition() {

--- a/crates/core/src/protocol/usenet/mod.rs
+++ b/crates/core/src/protocol/usenet/mod.rs
@@ -196,12 +196,13 @@ impl UsenetDownloader {
 
         // Verify CRC if available
         if let Some(expected_crc) = decoded.part_crc32.or(decoded.crc32)
-            && !yenc::verify_crc32(&decoded.data, expected_crc) {
-                return Err(crate::Error::Other(format!(
-                    "CRC32 mismatch for segment {}",
-                    segment.message_id
-                )));
-            }
+            && !yenc::verify_crc32(&decoded.data, expected_crc)
+        {
+            return Err(crate::Error::Other(format!(
+                "CRC32 mismatch for segment {}",
+                segment.message_id
+            )));
+        }
 
         Ok(decoded.data)
     }

--- a/crates/core/src/protocol/usenet/nntp.rs
+++ b/crates/core/src/protocol/usenet/nntp.rs
@@ -2,10 +2,53 @@
 //!
 //! Implements the NNTP protocol (RFC 3977) over TCP/TLS.
 //! Supports authentication, GROUP, ARTICLE, and BODY commands.
+//!
+//! Network reads/writes are wrapped in [`NNTP_IO_TIMEOUT`] so a stalled
+//! upstream cannot wedge a worker forever; the hostname is sanity-checked
+//! before [`TcpStream::connect`] so a corrupted config cannot turn a Usenet
+//! server entry into an SSRF gadget.
+
+use std::time::Duration;
 
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::TcpStream;
+use tokio::time::timeout;
 use tracing::debug;
+
+/// Cap on how long a single NNTP read/write may block. Servers that go quiet
+/// mid-article should be dropped instead of holding a connection slot
+/// forever; the connection pool can reconnect on the next attempt.
+const NNTP_IO_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Validate that `host` looks like a real DNS name or IP literal before
+/// handing it to the resolver. The previous code passed `&*config.host`
+/// straight into `TcpStream::connect`, so a bad config (e.g. a stray
+/// `"://"` prefix from copy-paste) would either fail with a confusing
+/// resolver error or, worse, accept a URI-style input that some resolvers
+/// special-case. This guard keeps the input shape predictable.
+fn validate_nntp_host(host: &str) -> Result<(), crate::Error> {
+    if host.is_empty() || host.len() > 253 {
+        return Err(crate::Error::Other(format!(
+            "NNTP host has invalid length: {} char(s)",
+            host.len()
+        )));
+    }
+    if host.contains("://") || host.contains('/') || host.contains(' ') {
+        return Err(crate::Error::Other(format!(
+            "NNTP host '{host}' contains URI / path / whitespace characters"
+        )));
+    }
+    // Allow IPv6 literals in bracketed or unbracketed form, or any DNS label
+    // (alnum, hyphen, dot, plus the colon separator some configs include
+    // for v6 zones — that case is filtered above by the / / ' ' rejections).
+    let allowed = |c: char| c.is_ascii_alphanumeric() || matches!(c, '-' | '.' | ':' | '[' | ']');
+    if !host.chars().all(allowed) {
+        return Err(crate::Error::Other(format!(
+            "NNTP host '{host}' contains characters outside [A-Za-z0-9.-:[]]"
+        )));
+    }
+    Ok(())
+}
 
 /// NNTP server configuration.
 #[derive(Debug, Clone)]
@@ -39,21 +82,37 @@ impl NntpConnection {
     pub async fn connect(config: &NntpServerConfig) -> Result<Self, crate::Error> {
         debug!("Connecting to NNTP server {}:{}", config.host, config.port);
 
-        let tcp = TcpStream::connect((&*config.host, config.port))
-            .await
-            .map_err(|e| crate::Error::Other(format!("NNTP connect failed: {e}")))?;
+        validate_nntp_host(&config.host)?;
+
+        let tcp = timeout(
+            NNTP_IO_TIMEOUT,
+            TcpStream::connect((&*config.host, config.port)),
+        )
+        .await
+        .map_err(|_| crate::Error::Other("NNTP connect timed out".into()))?
+        .map_err(|e| crate::Error::Other(format!("NNTP connect failed: {e}")))?;
 
         let (reader, writer): (
             Box<dyn tokio::io::AsyncRead + Unpin + Send>,
             Box<dyn tokio::io::AsyncWrite + Unpin + Send>,
         ) = if config.ssl {
+            // Build the TLS connector explicitly so the certificate /
+            // hostname checks stay enabled even if a future refactor
+            // swaps the helper. native_tls defaults are correct (verify
+            // cert chain + hostname); the explicit `false` calls below
+            // make a regression — e.g. someone toggling them on for
+            // local debugging — visible in code review.
+            let mut builder = native_tls::TlsConnector::builder();
+            builder.danger_accept_invalid_certs(false);
+            builder.danger_accept_invalid_hostnames(false);
             let connector = tokio_native_tls::TlsConnector::from(
-                native_tls::TlsConnector::new()
+                builder
+                    .build()
                     .map_err(|e| crate::Error::Other(format!("TLS error: {e}")))?,
             );
-            let tls = connector
-                .connect(&config.host, tcp)
+            let tls = timeout(NNTP_IO_TIMEOUT, connector.connect(&config.host, tcp))
                 .await
+                .map_err(|_| crate::Error::Other("NNTP TLS handshake timed out".into()))?
                 .map_err(|e| crate::Error::Other(format!("TLS handshake failed: {e}")))?;
             let (r, w) = tokio::io::split(tls);
             (Box::new(r), Box::new(w))
@@ -148,13 +207,14 @@ impl NntpConnection {
 
     /// Send a raw NNTP command.
     async fn send_command(&mut self, cmd: &str) -> Result<(), crate::Error> {
-        self.writer
-            .write_all(format!("{cmd}\r\n").as_bytes())
+        let payload = format!("{cmd}\r\n");
+        timeout(NNTP_IO_TIMEOUT, self.writer.write_all(payload.as_bytes()))
             .await
+            .map_err(|_| crate::Error::Other("NNTP write timed out".into()))?
             .map_err(|e| crate::Error::Other(format!("NNTP write error: {e}")))?;
-        self.writer
-            .flush()
+        timeout(NNTP_IO_TIMEOUT, self.writer.flush())
             .await
+            .map_err(|_| crate::Error::Other("NNTP flush timed out".into()))?
             .map_err(|e| crate::Error::Other(format!("NNTP flush error: {e}")))?;
         Ok(())
     }
@@ -162,9 +222,9 @@ impl NntpConnection {
     /// Read a single-line NNTP response.
     async fn read_response(&mut self) -> Result<NntpResponse, crate::Error> {
         let mut line = String::new();
-        self.reader
-            .read_line(&mut line)
+        timeout(NNTP_IO_TIMEOUT, self.reader.read_line(&mut line))
             .await
+            .map_err(|_| crate::Error::Other("NNTP read timed out".into()))?
             .map_err(|e| crate::Error::Other(format!("NNTP read error: {e}")))?;
 
         let line = line.trim_end();
@@ -184,10 +244,9 @@ impl NntpConnection {
 
         loop {
             line.clear();
-            let n = self
-                .reader
-                .read_line(&mut line)
+            let n = timeout(NNTP_IO_TIMEOUT, self.reader.read_line(&mut line))
                 .await
+                .map_err(|_| crate::Error::Other("NNTP read timed out".into()))?
                 .map_err(|e| crate::Error::Other(format!("NNTP read error: {e}")))?;
 
             if n == 0 {
@@ -263,5 +322,48 @@ impl NntpConnectionPool {
 
     pub fn priority(&self) -> u32 {
         self.config.priority
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_nntp_host;
+
+    #[test]
+    fn validate_accepts_dns_names_and_ip_literals() {
+        for ok in [
+            "news.example.com",
+            "alt.binaries.example.org",
+            "1.2.3.4",
+            "[::1]",
+            "[2001:db8::1]",
+        ] {
+            validate_nntp_host(ok).unwrap_or_else(|e| panic!("{ok} should be accepted: {e}"));
+        }
+    }
+
+    #[test]
+    fn validate_rejects_uri_like_inputs() {
+        // Misconfiguration patterns the previous code passed straight to
+        // resolver/connect, sometimes with surprising fallback behaviour.
+        for bad in [
+            "",
+            "nntps://news.example.com",
+            "news.example.com/path",
+            "news.example.com:563/extra",
+            "news .example.com",
+            "news.example.com\nfoo",
+        ] {
+            assert!(
+                validate_nntp_host(bad).is_err(),
+                "{bad:?} should be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_rejects_overlong_host() {
+        let huge = "a".repeat(254);
+        assert!(validate_nntp_host(&huge).is_err());
     }
 }

--- a/crates/core/src/protocol/usenet/nzb.rs
+++ b/crates/core/src/protocol/usenet/nzb.rs
@@ -35,9 +35,10 @@ impl NzbFile {
     pub fn filename(&self) -> String {
         // Try to extract quoted filename
         if let Some(start) = self.subject.find('"')
-            && let Some(end) = self.subject[start + 1..].find('"') {
-                return crate::sanitize_filename(&self.subject[start + 1..start + 1 + end]);
-            }
+            && let Some(end) = self.subject[start + 1..].find('"')
+        {
+            return crate::sanitize_filename(&self.subject[start + 1..start + 1 + end]);
+        }
         // Fallback: use subject as-is, sanitized
         crate::sanitize_filename(&self.subject)
     }

--- a/crates/core/src/protocol/usenet/yenc.rs
+++ b/crates/core/src/protocol/usenet/yenc.rs
@@ -48,12 +48,12 @@ pub fn decode_yenc(article_body: &[u8]) -> Result<YencDecoded, crate::Error> {
 
             // Check for =ypart header (multipart)
             if let Some(next_line) = lines.peek()
-                && next_line.starts_with("=ypart ") {
-                    let part_line = lines.next().unwrap();
-                    result.begin =
-                        extract_yenc_param(part_line, "begin").and_then(|s| s.parse().ok());
-                    result.end = extract_yenc_param(part_line, "end").and_then(|s| s.parse().ok());
-                }
+                && next_line.starts_with("=ypart ")
+            {
+                let part_line = lines.next().unwrap();
+                result.begin = extract_yenc_param(part_line, "begin").and_then(|s| s.parse().ok());
+                result.end = extract_yenc_param(part_line, "end").and_then(|s| s.parse().ok());
+            }
             in_body = true;
             continue;
         }

--- a/crates/core/src/retry.rs
+++ b/crates/core/src/retry.rs
@@ -64,10 +64,7 @@ pub enum RetryOutcome<T> {
 /// Execute an async operation with retries according to the given policy.
 ///
 /// The closure receives the current attempt number (0-based) and returns a `RetryOutcome`.
-pub async fn retry_with_policy<F, Fut, T>(
-    policy: &RetryPolicy,
-    mut f: F,
-) -> Result<T, crate::Error>
+pub async fn retry_with_policy<F, Fut, T>(policy: &RetryPolicy, mut f: F) -> Result<T, crate::Error>
 where
     F: FnMut(u32) -> Fut,
     Fut: Future<Output = RetryOutcome<T>>,
@@ -77,7 +74,10 @@ where
     for attempt in 0..=policy.max_retries {
         if attempt > 0 {
             let delay = policy.delay_for_attempt(attempt - 1);
-            warn!("Retrying (attempt {attempt}/{}) after {delay:?}", policy.max_retries);
+            warn!(
+                "Retrying (attempt {attempt}/{}) after {delay:?}",
+                policy.max_retries
+            );
             tokio::time::sleep(delay).await;
         }
 
@@ -136,9 +136,8 @@ mod tests {
             max_delay: Duration::from_millis(100),
         };
 
-        let result = retry_with_policy(&policy, |_attempt| async {
-            RetryOutcome::Success(42)
-        }).await;
+        let result =
+            retry_with_policy(&policy, |_attempt| async { RetryOutcome::Success(42) }).await;
 
         assert_eq!(result.unwrap(), 42);
     }
@@ -164,7 +163,8 @@ mod tests {
                     RetryOutcome::Success("done")
                 }
             }
-        }).await;
+        })
+        .await;
 
         assert_eq!(result.unwrap(), "done");
         assert_eq!(counter.load(std::sync::atomic::Ordering::SeqCst), 3);
@@ -187,7 +187,8 @@ mod tests {
                 c.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
                 RetryOutcome::Abort(crate::Error::Other("fatal".into()))
             }
-        }).await;
+        })
+        .await;
 
         assert!(result.is_err());
         assert_eq!(counter.load(std::sync::atomic::Ordering::SeqCst), 1);
@@ -203,7 +204,8 @@ mod tests {
 
         let result: Result<(), _> = retry_with_policy(&policy, |_attempt| async {
             RetryOutcome::Retry(crate::Error::Other("always fails".into()))
-        }).await;
+        })
+        .await;
 
         assert!(result.is_err());
     }

--- a/crates/core/src/storage.rs
+++ b/crates/core/src/storage.rs
@@ -418,21 +418,15 @@ impl Storage {
         Ok(())
     }
 
-    pub async fn get_download_metadata(
-        &self,
-        id: &str,
-    ) -> Result<Option<String>, crate::Error> {
+    pub async fn get_download_metadata(&self, id: &str) -> Result<Option<String>, crate::Error> {
         let db = self.db.lock().await;
         let mut stmt = db.prepare("SELECT metadata FROM downloads WHERE id = ?1")?;
-        let mut rows = stmt.query_map(rusqlite::params![id], |row| row.get::<_, Option<String>>(0))?;
+        let mut rows =
+            stmt.query_map(rusqlite::params![id], |row| row.get::<_, Option<String>>(0))?;
         Ok(rows.next().transpose()?.flatten())
     }
 
-    pub async fn set_download_priority(
-        &self,
-        id: &str,
-        priority: i32,
-    ) -> Result<(), crate::Error> {
+    pub async fn set_download_priority(&self, id: &str, priority: i32) -> Result<(), crate::Error> {
         let db = self.db.lock().await;
         db.execute(
             "UPDATE downloads SET priority = ?1 WHERE id = ?2",
@@ -678,8 +672,12 @@ impl Storage {
             "INSERT INTO rss_feeds (id, name, url, category, interval_minutes, enabled)
              VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
             rusqlite::params![
-                row.id, row.name, row.url, row.category,
-                row.interval_minutes as i64, row.enabled as i64,
+                row.id,
+                row.name,
+                row.url,
+                row.category,
+                row.interval_minutes as i64,
+                row.enabled as i64,
             ],
         )?;
         Ok(())
@@ -752,9 +750,7 @@ impl Storage {
             "SELECT id, username, created_at, expires_at, last_seen_at \
              FROM sessions WHERE id = ?1",
         )?;
-        let result = stmt
-            .query_row(rusqlite::params![id], row_to_session)
-            .ok();
+        let result = stmt.query_row(rusqlite::params![id], row_to_session).ok();
         Ok(result)
     }
 
@@ -887,9 +883,7 @@ impl Storage {
             "SELECT id, poll_token_hash, device_name, source_ip, user_agent, fingerprint, status, api_token_plain, api_token_id, created_at, expires_at \
              FROM pairing_requests WHERE poll_token_hash = ?1",
         )?;
-        let result = stmt
-            .query_row(rusqlite::params![hash], row_to_pairing)
-            .ok();
+        let result = stmt.query_row(rusqlite::params![hash], row_to_pairing).ok();
         Ok(result)
     }
 
@@ -1195,7 +1189,13 @@ mod tests {
 
         storage.revoke_api_token("tok-1").await.unwrap();
         // Revoked rows are filtered out of the auth-lookup path.
-        assert!(storage.get_api_token_by_hash("hash-aaa").await.unwrap().is_none());
+        assert!(
+            storage
+                .get_api_token_by_hash("hash-aaa")
+                .await
+                .unwrap()
+                .is_none()
+        );
         // …but still show up in the management list.
         assert_eq!(storage.list_api_tokens().await.unwrap().len(), 1);
     }
@@ -1230,10 +1230,7 @@ mod tests {
         assert!(ok);
 
         // Second approve is a no-op because the row is no longer pending.
-        let ok2 = storage
-            .approve_pairing("pair-1", "x", "y")
-            .await
-            .unwrap();
+        let ok2 = storage.approve_pairing("pair-1", "x", "y").await.unwrap();
         assert!(!ok2);
 
         let consumed = storage
@@ -1244,11 +1241,13 @@ mod tests {
         assert_eq!(consumed.api_token_plain.as_deref(), Some("plain-token"));
 
         // Subsequent consume returns nothing — the row was deleted.
-        assert!(storage
-            .consume_pairing_by_poll_hash("poll-hash")
-            .await
-            .unwrap()
-            .is_none());
+        assert!(
+            storage
+                .consume_pairing_by_poll_hash("poll-hash")
+                .await
+                .unwrap()
+                .is_none()
+        );
     }
 
     #[tokio::test]
@@ -1272,11 +1271,13 @@ mod tests {
         assert!(storage.deny_pairing("pair-2").await.unwrap());
 
         // Consume returns None because the row is denied, not approved.
-        assert!(storage
-            .consume_pairing_by_poll_hash("deny-hash")
-            .await
-            .unwrap()
-            .is_none());
+        assert!(
+            storage
+                .consume_pairing_by_poll_hash("deny-hash")
+                .await
+                .unwrap()
+                .is_none()
+        );
 
         // Status is visible via the hash-lookup.
         let row = storage

--- a/crates/core/tests/coordinator.rs
+++ b/crates/core/tests/coordinator.rs
@@ -64,12 +64,7 @@ async fn test_add_download_with_filename() {
 async fn test_add_download_with_priority() {
     let coord = test_coordinator();
     let id = coord
-        .add_download_with_options(
-            "https://example.com/movie.mp4",
-            None,
-            None,
-            5,
-        )
+        .add_download_with_options("https://example.com/movie.mp4", None, None, 5)
         .await
         .unwrap();
 

--- a/crates/core/tests/storage_tests.rs
+++ b/crates/core/tests/storage_tests.rs
@@ -224,7 +224,10 @@ async fn test_count_by_status() {
     let storage = Storage::open_memory().unwrap();
 
     for i in 0..5 {
-        let dl = make_download(&format!("dl-cnt-{i}"), &format!("https://example.com/{i}.zip"));
+        let dl = make_download(
+            &format!("dl-cnt-{i}"),
+            &format!("https://example.com/{i}.zip"),
+        );
         storage.insert_download(&dl).await.unwrap();
     }
 
@@ -273,7 +276,10 @@ async fn test_clear_history() {
             &format!("https://example.com/{i}.zip"),
         );
         storage.insert_download(&dl).await.unwrap();
-        storage.move_to_history(&format!("dl-hc-{i}")).await.unwrap();
+        storage
+            .move_to_history(&format!("dl-hc-{i}"))
+            .await
+            .unwrap();
     }
 
     let history = storage.get_history().await.unwrap();
@@ -421,14 +427,8 @@ async fn test_update_state_roundtrip() {
 async fn test_update_state_overwrite() {
     let storage = Storage::open_memory().unwrap();
 
-    storage
-        .set_update_state("key", "value1")
-        .await
-        .unwrap();
-    storage
-        .set_update_state("key", "value2")
-        .await
-        .unwrap();
+    storage.set_update_state("key", "value1").await.unwrap();
+    storage.set_update_state("key", "value2").await.unwrap();
 
     let val = storage.get_update_state("key").await.unwrap();
     assert_eq!(val.as_deref(), Some("value2"));
@@ -614,10 +614,7 @@ async fn test_on_disk_persistence() {
         let storage = Storage::open(db_path, dl_dir, tmp_dir).unwrap();
         let fetched = storage.get_download("persist-1").await.unwrap();
         assert!(fetched.is_some());
-        assert_eq!(
-            fetched.unwrap().url,
-            "https://example.com/persist.zip"
-        );
+        assert_eq!(fetched.unwrap().url, "https://example.com/persist.zip");
     }
 }
 

--- a/crates/extractors/src/generic/metadata.rs
+++ b/crates/extractors/src/generic/metadata.rs
@@ -5,7 +5,7 @@ use tracing::debug;
 
 use crate::traits::{MediaStream, StreamProtocol};
 
-use super::{resolve_url, GenericExtractor};
+use super::{GenericExtractor, resolve_url};
 
 /// Extract video URLs from OpenGraph meta tags.
 ///
@@ -17,9 +17,7 @@ pub fn extract_og_video(html: &str, base_url: &str) -> Vec<MediaStream> {
     let og_tags = ["og:video", "og:video:url", "og:video:secure_url"];
 
     for tag in og_tags {
-        let selector_str = format!(
-            r#"meta[property="{tag}"], meta[name="{tag}"]"#
-        );
+        let selector_str = format!(r#"meta[property="{tag}"], meta[name="{tag}"]"#);
         if let Ok(sel) = Selector::parse(&selector_str) {
             for elem in document.select(&sel) {
                 if let Some(content) = elem.value().attr("content") {
@@ -28,7 +26,9 @@ pub fn extract_og_video(html: &str, base_url: &str) -> Vec<MediaStream> {
                     }
                     if let Some(url) = resolve_url(base_url, content) {
                         // Skip flash/embed URLs
-                        if url.contains(".swf") || url.contains("embed") && !GenericExtractor::is_media_url(&url) {
+                        if url.contains(".swf")
+                            || url.contains("embed") && !GenericExtractor::is_media_url(&url)
+                        {
                             continue;
                         }
                         let proto = GenericExtractor::protocol_from_url(&url)
@@ -43,7 +43,10 @@ pub fn extract_og_video(html: &str, base_url: &str) -> Vec<MediaStream> {
 
     // Also check og:video:type for protocol hints
     if let Ok(sel) = Selector::parse(r#"meta[property="og:video:type"]"#)
-        && let Some(content) = document.select(&sel).next().and_then(|elem| elem.value().attr("content"))
+        && let Some(content) = document
+            .select(&sel)
+            .next()
+            .and_then(|elem| elem.value().attr("content"))
         && let Some(proto) = GenericExtractor::protocol_from_content_type(content)
     {
         for stream in &mut streams {
@@ -73,7 +76,9 @@ pub fn extract_twitter_player(html: &str, base_url: &str) -> Vec<MediaStream> {
                     if content.is_empty() {
                         continue;
                     }
-                    if let Some(url) = resolve_url(base_url, content).filter(|u| GenericExtractor::is_media_url(u)) {
+                    if let Some(url) =
+                        resolve_url(base_url, content).filter(|u| GenericExtractor::is_media_url(u))
+                    {
                         let proto = GenericExtractor::protocol_from_url(&url)
                             .unwrap_or(StreamProtocol::Http);
                         debug!("Found Twitter player stream: {}", url);
@@ -128,11 +133,15 @@ fn extract_video_object_urls(
     }
 
     for key in &["contentUrl", "embedUrl"] {
-        if let Some(url) = json.get(key).and_then(|v| v.as_str()).and_then(|url_str| resolve_url(base_url, url_str))
-            && (GenericExtractor::is_media_url(&url) || url.contains(".m3u8") || url.contains(".mpd"))
+        if let Some(url) = json
+            .get(key)
+            .and_then(|v| v.as_str())
+            .and_then(|url_str| resolve_url(base_url, url_str))
+            && (GenericExtractor::is_media_url(&url)
+                || url.contains(".m3u8")
+                || url.contains(".mpd"))
         {
-            let proto = GenericExtractor::protocol_from_url(&url)
-                .unwrap_or(StreamProtocol::Http);
+            let proto = GenericExtractor::protocol_from_url(&url).unwrap_or(StreamProtocol::Http);
             debug!("Found JSON-LD {}: {}", key, url);
             streams.push(GenericExtractor::stream_from_url(&url, proto));
         }

--- a/crates/extractors/src/generic/mod.rs
+++ b/crates/extractors/src/generic/mod.rs
@@ -22,8 +22,8 @@ use crate::traits::{ExtractedMedia, Extractor, MediaStream, StreamProtocol};
 
 /// Media file extensions that indicate a direct download.
 const MEDIA_EXTENSIONS: &[&str] = &[
-    ".mp4", ".mkv", ".avi", ".mov", ".wmv", ".flv", ".webm", ".m4v", ".ts",
-    ".mp3", ".flac", ".wav", ".ogg", ".aac", ".m4a", ".opus", ".wma",
+    ".mp4", ".mkv", ".avi", ".mov", ".wmv", ".flv", ".webm", ".m4v", ".ts", ".mp3", ".flac",
+    ".wav", ".ogg", ".aac", ".m4a", ".opus", ".wma",
 ];
 
 /// Streaming manifest extensions.
@@ -156,7 +156,9 @@ impl GenericExtractor {
         // Phase 7: iframe recursion
         if depth < MAX_IFRAME_DEPTH
             && streams.is_empty()
-            && let Ok(iframe_streams) = self.extract_from_iframes(client, html, page_url, depth).await
+            && let Ok(iframe_streams) = self
+                .extract_from_iframes(client, html, page_url, depth)
+                .await
         {
             streams.extend(iframe_streams);
         }
@@ -173,7 +175,8 @@ impl GenericExtractor {
         let mut streams = Vec::new();
 
         // Find m3u8 URLs
-        let m3u8_re = Regex::new(r#"["\']?(https?://[^"'\s]+\.m3u8(?:\?[^"'\s]*)?)["\']?"#).unwrap();
+        let m3u8_re =
+            Regex::new(r#"["\']?(https?://[^"'\s]+\.m3u8(?:\?[^"'\s]*)?)["\']?"#).unwrap();
         for cap in m3u8_re.captures_iter(html) {
             if let Some(url) = cap.get(1) {
                 debug!("Found m3u8 in script: {}", url.as_str());
@@ -191,12 +194,16 @@ impl GenericExtractor {
         }
 
         // Find direct mp4/webm URLs in JavaScript (but not in HTML href/src which we handle elsewhere)
-        let mp4_re = Regex::new(r#"["\']?(https?://[^"'\s]+\.(?:mp4|webm)(?:\?[^"'\s]*)?)["\']?"#).unwrap();
+        let mp4_re =
+            Regex::new(r#"["\']?(https?://[^"'\s]+\.(?:mp4|webm)(?:\?[^"'\s]*)?)["\']?"#).unwrap();
         for cap in mp4_re.captures_iter(html) {
             if let Some(url) = cap.get(1) {
                 let url_str = url.as_str();
                 // Skip obvious non-video mp4 URLs (thumbnails, etc.)
-                if !url_str.contains("thumb") && !url_str.contains("poster") && !url_str.contains("preview") {
+                if !url_str.contains("thumb")
+                    && !url_str.contains("poster")
+                    && !url_str.contains("preview")
+                {
                     debug!("Found media URL in script: {}", url_str);
                     streams.push(Self::stream_from_url(url_str, StreamProtocol::Http));
                 }
@@ -214,7 +221,11 @@ impl GenericExtractor {
         // <video src="..."> and <audio src="...">
         let media_sel = Selector::parse("video[src], audio[src]").unwrap();
         for elem in document.select(&media_sel) {
-            if let Some(url) = elem.value().attr("src").and_then(|src| resolve_url(base_url, src)) {
+            if let Some(url) = elem
+                .value()
+                .attr("src")
+                .and_then(|src| resolve_url(base_url, src))
+            {
                 let proto = Self::protocol_from_url(&url).unwrap_or(StreamProtocol::Http);
                 streams.push(Self::stream_from_url(&url, proto));
             }
@@ -223,7 +234,11 @@ impl GenericExtractor {
         // <source> tags inside <video> or <audio>
         let source_sel = Selector::parse("video source, audio source").unwrap();
         for elem in document.select(&source_sel) {
-            if let Some(url) = elem.value().attr("src").and_then(|src| resolve_url(base_url, src)) {
+            if let Some(url) = elem
+                .value()
+                .attr("src")
+                .and_then(|src| resolve_url(base_url, src))
+            {
                 let proto = Self::protocol_from_url(&url).unwrap_or(StreamProtocol::Http);
                 let mime = elem.value().attr("type").unwrap_or("").to_string();
                 let mut stream = Self::stream_from_url(&url, proto);
@@ -242,14 +257,17 @@ impl GenericExtractor {
         let mut streams = Vec::new();
 
         // RSS <enclosure url="..." type="..."/>
-        let enclosure_re = Regex::new(
-            r#"<enclosure[^>]+url=["']([^"']+)["'][^>]*(?:type=["']([^"']+)["'])?"#
-        ).unwrap();
+        let enclosure_re =
+            Regex::new(r#"<enclosure[^>]+url=["']([^"']+)["'][^>]*(?:type=["']([^"']+)["'])?"#)
+                .unwrap();
         for cap in enclosure_re.captures_iter(html) {
             if let Some(url) = cap.get(1) {
                 let url_str = url.as_str();
                 let ct = cap.get(2).map(|m| m.as_str()).unwrap_or("");
-                if ct.starts_with("video/") || ct.starts_with("audio/") || Self::is_media_url(url_str) {
+                if ct.starts_with("video/")
+                    || ct.starts_with("audio/")
+                    || Self::is_media_url(url_str)
+                {
                     let proto = Self::protocol_from_url(url_str).unwrap_or(StreamProtocol::Http);
                     streams.push(Self::stream_from_url(url_str, proto));
                 }
@@ -275,7 +293,8 @@ impl GenericExtractor {
                 .select(&iframe_sel)
                 .filter_map(|elem| {
                     let src = elem.value().attr("src")?;
-                    if src.is_empty() || src.starts_with("about:") || src.starts_with("javascript:") {
+                    if src.is_empty() || src.starts_with("about:") || src.starts_with("javascript:")
+                    {
                         return None;
                     }
                     resolve_url(base_url, src)
@@ -344,16 +363,14 @@ impl Extractor for GenericExtractor {
 
         // Phase 1b: HEAD request to check Content-Type
         if let Ok(resp) = client.head(url).send().await
-            && let Some(proto) = resp.headers().get("content-type")
+            && let Some(proto) = resp
+                .headers()
+                .get("content-type")
                 .and_then(|ct| ct.to_str().ok())
                 .and_then(Self::protocol_from_content_type)
         {
             return Ok(ExtractedMedia {
-                title: url
-                    .rsplit('/')
-                    .next()
-                    .unwrap_or("Download")
-                    .to_string(),
+                title: url.rsplit('/').next().unwrap_or("Download").to_string(),
                 streams: vec![Self::stream_from_url(url, proto)],
             });
         }
@@ -468,8 +485,7 @@ mod tests {
                 </video>
             </body></html>
         "#;
-        let streams =
-            GenericExtractor::extract_html5_media(html, "https://example.com");
+        let streams = GenericExtractor::extract_html5_media(html, "https://example.com");
         assert_eq!(streams.len(), 2);
         assert!(streams[0].url.ends_with("/video/720p.mp4"));
         assert!(streams[1].url.ends_with("/video/stream.m3u8"));
@@ -525,9 +541,6 @@ mod tests {
     #[test]
     fn test_page_title() {
         let html = "<html><head><title>My Video Page</title></head><body></body></html>";
-        assert_eq!(
-            extract_page_title(html),
-            Some("My Video Page".to_string())
-        );
+        assert_eq!(extract_page_title(html), Some("My Video Page".to_string()));
     }
 }

--- a/crates/extractors/src/generic/players.rs
+++ b/crates/extractors/src/generic/players.rs
@@ -12,7 +12,7 @@ use tracing::debug;
 
 use crate::traits::{MediaStream, StreamProtocol};
 
-use super::{resolve_url, GenericExtractor};
+use super::{GenericExtractor, resolve_url};
 
 /// Detect JW Player embeds and extract stream URLs.
 ///
@@ -26,8 +26,9 @@ pub fn detect_jwplayer(html: &str, base_url: &str) -> Vec<MediaStream> {
 
     // Pattern 1: jwplayer().setup() with file
     let setup_re = Regex::new(
-        r#"jwplayer\s*\([^)]*\)\s*\.\s*setup\s*\(\s*\{[^}]*?["']?file["']?\s*:\s*["']([^"']+)["']"#
-    ).unwrap();
+        r#"jwplayer\s*\([^)]*\)\s*\.\s*setup\s*\(\s*\{[^}]*?["']?file["']?\s*:\s*["']([^"']+)["']"#,
+    )
+    .unwrap();
     for cap in setup_re.captures_iter(html) {
         if let Some(url) = cap.get(1) {
             add_media_stream(&mut streams, url.as_str(), base_url, "JW Player setup.file");
@@ -36,9 +37,7 @@ pub fn detect_jwplayer(html: &str, base_url: &str) -> Vec<MediaStream> {
 
     // Pattern 2: Generic file property near jwplayer references
     if html.contains("jwplayer") || html.contains("jwDefaults") || html.contains("jw-video") {
-        let file_re = Regex::new(
-            r#"["']?file["']?\s*:\s*["'](https?://[^"']+)["']"#
-        ).unwrap();
+        let file_re = Regex::new(r#"["']?file["']?\s*:\s*["'](https?://[^"']+)["']"#).unwrap();
         for cap in file_re.captures_iter(html) {
             if let Some(url) = cap.get(1) {
                 let url_str = url.as_str();
@@ -52,12 +51,8 @@ pub fn detect_jwplayer(html: &str, base_url: &str) -> Vec<MediaStream> {
         }
 
         // Pattern 3: sources array
-        let sources_re = Regex::new(
-            r#"["']?sources["']?\s*:\s*\[([^\]]+)\]"#
-        ).unwrap();
-        let src_file_re = Regex::new(
-            r#"["']?file["']?\s*:\s*["'](https?://[^"']+)["']"#
-        ).unwrap();
+        let sources_re = Regex::new(r#"["']?sources["']?\s*:\s*\[([^\]]+)\]"#).unwrap();
+        let src_file_re = Regex::new(r#"["']?file["']?\s*:\s*["'](https?://[^"']+)["']"#).unwrap();
         for cap in sources_re.captures_iter(html) {
             if let Some(inner) = cap.get(1) {
                 for src_cap in src_file_re.captures_iter(inner.as_str()) {
@@ -81,11 +76,11 @@ pub fn detect_videojs(html: &str, base_url: &str) -> Vec<MediaStream> {
     let mut streams = Vec::new();
 
     // data-setup attribute with sources
-    let data_setup_re = Regex::new(
-        r#"data-setup\s*=\s*'([^']+)'"#
-    ).unwrap();
+    let data_setup_re = Regex::new(r#"data-setup\s*=\s*'([^']+)'"#).unwrap();
     for cap in data_setup_re.captures_iter(html) {
-        if let Some(json) = cap.get(1).and_then(|json_str| serde_json::from_str::<serde_json::Value>(json_str.as_str()).ok())
+        if let Some(json) = cap
+            .get(1)
+            .and_then(|json_str| serde_json::from_str::<serde_json::Value>(json_str.as_str()).ok())
             && let Some(sources) = json.get("sources").and_then(|s| s.as_array())
         {
             for source in sources {
@@ -98,9 +93,9 @@ pub fn detect_videojs(html: &str, base_url: &str) -> Vec<MediaStream> {
 
     // videojs().src() calls
     if html.contains("videojs") || html.contains("video-js") {
-        let src_re = Regex::new(
-            r#"\.src\s*\(\s*\{[^}]*["']?src["']?\s*:\s*["'](https?://[^"']+)["']"#
-        ).unwrap();
+        let src_re =
+            Regex::new(r#"\.src\s*\(\s*\{[^}]*["']?src["']?\s*:\s*["'](https?://[^"']+)["']"#)
+                .unwrap();
         for cap in src_re.captures_iter(html) {
             if let Some(url) = cap.get(1) {
                 add_media_stream(&mut streams, url.as_str(), base_url, "Video.js src()");
@@ -122,9 +117,9 @@ pub fn detect_brightcove(html: &str, base_url: &str) -> Vec<MediaStream> {
     // Brightcove often includes source URLs in data attributes or script configs
     if html.contains("brightcove") || html.contains("bc-player") || html.contains("data-video-id") {
         // Look for video sources in Brightcove config
-        let source_re = Regex::new(
-            r#"["']?src["']?\s*:\s*["'](https?://[^"']+\.(?:m3u8|mpd|mp4)[^"']*)["']"#
-        ).unwrap();
+        let source_re =
+            Regex::new(r#"["']?src["']?\s*:\s*["'](https?://[^"']+\.(?:m3u8|mpd|mp4)[^"']*)["']"#)
+                .unwrap();
         for cap in source_re.captures_iter(html) {
             if let Some(url) = cap.get(1) {
                 add_media_stream(&mut streams, url.as_str(), base_url, "Brightcove");
@@ -145,8 +140,9 @@ pub fn detect_flowplayer(html: &str, base_url: &str) -> Vec<MediaStream> {
     if html.contains("flowplayer") {
         // Extract clip sources
         let clip_re = Regex::new(
-            r#"["']?src["']?\s*:\s*["'](https?://[^"']+\.(?:m3u8|mpd|mp4|webm)[^"']*)["']"#
-        ).unwrap();
+            r#"["']?src["']?\s*:\s*["'](https?://[^"']+\.(?:m3u8|mpd|mp4|webm)[^"']*)["']"#,
+        )
+        .unwrap();
         for cap in clip_re.captures_iter(html) {
             if let Some(url) = cap.get(1) {
                 add_media_stream(&mut streams, url.as_str(), base_url, "Flowplayer");
@@ -168,8 +164,9 @@ pub fn detect_wistia(html: &str, base_url: &str) -> Vec<MediaStream> {
     if html.contains("wistia") {
         // Wistia often embeds asset URLs in JSON config
         let asset_re = Regex::new(
-            r#"["']?url["']?\s*:\s*["'](https?://[^"']*wistia[^"']*\.(?:m3u8|mp4|bin)[^"']*)["']"#
-        ).unwrap();
+            r#"["']?url["']?\s*:\s*["'](https?://[^"']*wistia[^"']*\.(?:m3u8|mp4|bin)[^"']*)["']"#,
+        )
+        .unwrap();
         for cap in asset_re.captures_iter(html) {
             if let Some(url) = cap.get(1) {
                 add_media_stream(&mut streams, url.as_str(), base_url, "Wistia");
@@ -201,7 +198,12 @@ fn add_media_stream(streams: &mut Vec<MediaStream>, url: &str, base_url: &str, s
     }
 
     let proto = GenericExtractor::protocol_from_url(&resolved).unwrap_or(StreamProtocol::Http);
-    debug!("Found media via {}: {} ({})", source, resolved, format!("{:?}", proto));
+    debug!(
+        "Found media via {}: {} ({})",
+        source,
+        resolved,
+        format!("{:?}", proto)
+    );
     streams.push(GenericExtractor::stream_from_url(&resolved, proto));
 }
 

--- a/crates/extractors/src/youtube/n_challenge.rs
+++ b/crates/extractors/src/youtube/n_challenge.rs
@@ -6,13 +6,39 @@
 
 use std::collections::HashMap;
 use std::sync::Mutex;
+use std::time::{Duration, Instant};
 
 use tracing::{debug, warn};
 
 use crate::ExtractorError;
 
-/// In-memory cache for player JS code, keyed by player URL.
-static PLAYER_JS_CACHE: std::sync::LazyLock<Mutex<HashMap<String, String>>> =
+/// Maximum age of a cached player.js entry. YouTube rotates the player JS
+/// roughly daily; refreshing every 12 h keeps us aligned without spamming
+/// their CDN. Without a TTL the previous in-memory cache held stale JS
+/// forever, which is what bit n-function extraction whenever YouTube
+/// shipped new obfuscation.
+const PLAYER_JS_CACHE_TTL: Duration = Duration::from_secs(12 * 60 * 60);
+
+/// Hard cap on the in-memory player.js cache. YouTube only has a handful of
+/// player versions live at any time; we don't need more.
+const PLAYER_JS_CACHE_MAX_ENTRIES: usize = 8;
+
+/// Cap on how long the QuickJS interpreter may run while transforming a
+/// single `n` value. The player JS comes from YouTube and is normally
+/// trusted, but a malicious or corrupted variant could otherwise hang the
+/// extractor thread indefinitely.
+const N_TRANSFORM_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Clone)]
+struct PlayerJsEntry {
+    js: String,
+    fetched_at: Instant,
+}
+
+/// In-memory cache for player JS code, keyed by player URL. Entries expire
+/// after [`PLAYER_JS_CACHE_TTL`] and the cache is capped at
+/// [`PLAYER_JS_CACHE_MAX_ENTRIES`] (oldest entry evicted on insert).
+static PLAYER_JS_CACHE: std::sync::LazyLock<Mutex<HashMap<String, PlayerJsEntry>>> =
     std::sync::LazyLock::new(|| Mutex::new(HashMap::new()));
 
 /// Fetch and cache the player JS source code.
@@ -20,12 +46,17 @@ async fn get_player_js(
     client: &reqwest::Client,
     player_js_url: &str,
 ) -> Result<String, ExtractorError> {
-    // Check cache
+    // Check cache, honouring TTL.
     {
-        let cache = PLAYER_JS_CACHE.lock().unwrap_or_else(|e| e.into_inner());
-        if let Some(js) = cache.get(player_js_url) {
-            debug!("Player JS cache hit: {player_js_url}");
-            return Ok(js.clone());
+        let mut cache = PLAYER_JS_CACHE.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(entry) = cache.get(player_js_url) {
+            if entry.fetched_at.elapsed() < PLAYER_JS_CACHE_TTL {
+                debug!("Player JS cache hit: {player_js_url}");
+                return Ok(entry.js.clone());
+            }
+            // Stale — drop the entry so the fetch path repopulates.
+            cache.remove(player_js_url);
+            debug!("Player JS cache miss (stale): {player_js_url}");
         }
     }
 
@@ -38,10 +69,24 @@ async fn get_player_js(
 
     let js = resp.text().await?;
 
-    // Cache it
+    // Cache it, evicting the oldest entry first if we're at capacity.
     {
         let mut cache = PLAYER_JS_CACHE.lock().unwrap_or_else(|e| e.into_inner());
-        cache.insert(player_js_url.to_string(), js.clone());
+        if cache.len() >= PLAYER_JS_CACHE_MAX_ENTRIES
+            && let Some(oldest) = cache
+                .iter()
+                .min_by_key(|(_, v)| v.fetched_at)
+                .map(|(k, _)| k.clone())
+        {
+            cache.remove(&oldest);
+        }
+        cache.insert(
+            player_js_url.to_string(),
+            PlayerJsEntry {
+                js: js.clone(),
+                fetched_at: Instant::now(),
+            },
+        );
     }
 
     Ok(js)
@@ -284,13 +329,21 @@ pub async fn transform_n_param(
 }
 
 /// Execute the N-parameter transform function using QuickJS.
+///
+/// QuickJS is configured with a 5-second deadline via its interrupt handler
+/// so a malicious or corrupt player JS can't hang the extractor thread, and
+/// a 16 MiB heap so a malformed transform can't OOM the host. The runtime is
+/// thrown away after every call — the cached player JS is the only state we
+/// keep across invocations.
 fn execute_n_transform(n_function_js: &str, n_value: &str) -> Result<String, ExtractorError> {
-    // Run JS in a blocking context since rquickjs is sync
     let n_function_js = n_function_js.to_string();
     let n_value = n_value.to_string();
 
     let rt = rquickjs::Runtime::new()
         .map_err(|e| ExtractorError::NChallenge(format!("Failed to create JS runtime: {e}")))?;
+    rt.set_memory_limit(16 * 1024 * 1024);
+    let deadline = Instant::now() + N_TRANSFORM_TIMEOUT;
+    rt.set_interrupt_handler(Some(Box::new(move || Instant::now() >= deadline)));
     let ctx = rquickjs::Context::full(&rt)
         .map_err(|e| ExtractorError::NChallenge(format!("Failed to create JS context: {e}")))?;
 

--- a/crates/extractors/src/youtube/n_challenge.rs
+++ b/crates/extractors/src/youtube/n_challenge.rs
@@ -115,8 +115,13 @@ fn extract_n_function(player_js: &str) -> Result<String, ExtractorError> {
     let re = regex::Regex::new(patterns[0]).map_err(|e| ExtractorError::Other(e.to_string()))?;
 
     if let Some(caps) = re.captures(player_js) {
-        let func_name = caps.get(1)
-            .ok_or_else(|| ExtractorError::Other("N-challenge regex matched but capture group 1 missing".into()))?
+        let func_name = caps
+            .get(1)
+            .ok_or_else(|| {
+                ExtractorError::Other(
+                    "N-challenge regex matched but capture group 1 missing".into(),
+                )
+            })?
             .as_str();
         let array_idx = caps.get(2).map(|m| m.as_str());
 
@@ -165,10 +170,7 @@ fn extract_named_function(js: &str, name: &str) -> Option<String> {
         && let Some(end) = find_closing_brace(js, m.end() - 1)
     {
         let func_offset = m.as_str().find("function").unwrap_or(0);
-        return Some(format!(
-            "var {name}={}",
-            &js[m.start() + func_offset..=end]
-        ));
+        return Some(format!("var {name}={}", &js[m.start() + func_offset..=end]));
     }
 
     // Try: function name(a){...}

--- a/crates/plugin-runtime/build.rs
+++ b/crates/plugin-runtime/build.rs
@@ -1,0 +1,45 @@
+//! Build-time guards for the plugin-runtime crate.
+//!
+//! The plugin registry trusts whatever Ed25519 public key is baked into the
+//! binary at compile time (see `registry::AMIGO_REGISTRY_PUBLIC_KEY`). For
+//! release builds we refuse to compile without `AMIGO_REGISTRY_PUBKEY_HEX`
+//! pointing at a real 32-byte key, otherwise an opaque "all zeros" key would
+//! ship and any third party with the matching all-zero private key could
+//! forge signatures for the plugin marketplace.
+//!
+//! Dev / debug / test builds may still compile without the env var; the
+//! runtime falls back to "verification disabled" with a loud warning.
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=AMIGO_REGISTRY_PUBKEY_HEX");
+    println!("cargo:rerun-if-env-changed=PROFILE");
+
+    let profile = std::env::var("PROFILE").unwrap_or_default();
+    let pubkey_hex = std::env::var("AMIGO_REGISTRY_PUBKEY_HEX").ok();
+
+    if profile == "release" {
+        let Some(hex) = pubkey_hex else {
+            panic!(
+                "AMIGO_REGISTRY_PUBKEY_HEX must be set for release builds. \
+                 Set it to the hex-encoded 32-byte Ed25519 public key of the \
+                 plugin registry signer (64 lowercase hex chars)."
+            );
+        };
+        if hex.len() != 64 {
+            panic!(
+                "AMIGO_REGISTRY_PUBKEY_HEX must be exactly 64 hex chars, got {}",
+                hex.len()
+            );
+        }
+        if !hex.chars().all(|c| c.is_ascii_hexdigit()) {
+            panic!("AMIGO_REGISTRY_PUBKEY_HEX must be hex (0-9, a-f, A-F) only");
+        }
+        let zero = "0".repeat(64);
+        if hex.eq_ignore_ascii_case(&zero) {
+            panic!(
+                "AMIGO_REGISTRY_PUBKEY_HEX is the all-zero placeholder; \
+                 release builds must pin a real Ed25519 public key."
+            );
+        }
+    }
+}

--- a/crates/plugin-runtime/src/host_api.rs
+++ b/crates/plugin-runtime/src/host_api.rs
@@ -26,6 +26,60 @@ pub type CaptchaFuture =
 /// Per-plugin cookie jars: `plugin_id → domain → name → value`.
 type CookieJars = HashMap<String, HashMap<String, HashMap<String, String>>>;
 
+// --- Input-size limits for the parsing helpers (audit finding #11) ---
+//
+// All of these guard the host *outside* the QuickJS context. The 64 MiB
+// memory cap on the JS side does not protect against `amigo.htmlQueryAll`
+// allocating gigabytes on the host heap, so we cap inputs before they reach
+// `scraper`, `regex`, or the base64 decoder.
+
+/// Cap on regex pattern length. Real-world hoster regexes top out at a few
+/// hundred chars; anything bigger is almost certainly a ReDoS payload or a
+/// plugin bug.
+const MAX_REGEX_PATTERN_BYTES: usize = 4 * 1024;
+
+/// Cap on the haystack passed to regex helpers. 4 MiB is comfortably larger
+/// than any HTML page a plugin needs to parse with regex (use the proper
+/// `htmlQuery*` family for big documents anyway).
+const MAX_REGEX_TEXT_BYTES: usize = 4 * 1024 * 1024;
+
+/// Compile-time cap for a single regex's NFA.
+const REGEX_COMPILE_SIZE_LIMIT: usize = 1024 * 1024;
+
+/// Compile-time cap for a regex's DFA cache.
+const REGEX_DFA_SIZE_LIMIT: usize = 2 * 1024 * 1024;
+
+/// Cap on HTML inputs to scraper-based helpers. 8 MiB is well past any
+/// legitimate page; bigger inputs are pathological-nesting OOM bombs.
+const MAX_HTML_BYTES: usize = 8 * 1024 * 1024;
+
+/// Cap on base64 input length. The host-side decoder allocates ~3/4 of the
+/// input length on the heap, so unbounded inputs map to unbounded host RAM.
+const MAX_BASE64_INPUT_BYTES: usize = 8 * 1024 * 1024;
+
+fn enforce_input_limit(field: &str, len: usize, max: usize) -> Result<(), String> {
+    if len > max {
+        Err(format!(
+            "{field} too large ({} bytes; limit {} bytes)",
+            len, max
+        ))
+    } else {
+        Ok(())
+    }
+}
+
+/// Compile a regex with the global plugin-side size limits applied. Returns
+/// the compiled `Regex` or a string error suitable for surfacing to the JS
+/// caller.
+fn compile_plugin_regex(pattern: &str) -> Result<regex::Regex, String> {
+    enforce_input_limit("regex pattern", pattern.len(), MAX_REGEX_PATTERN_BYTES)?;
+    regex::RegexBuilder::new(pattern)
+        .size_limit(REGEX_COMPILE_SIZE_LIMIT)
+        .dfa_size_limit(REGEX_DFA_SIZE_LIMIT)
+        .build()
+        .map_err(|e| format!("invalid regex: {e}"))
+}
+
 /// Shared state for the Host API, passed into every plugin call.
 #[derive(Clone)]
 pub struct HostApi {
@@ -280,7 +334,10 @@ impl HostApi {
     // --- Parsing helpers ---
 
     pub fn regex_match(&self, pattern: &str, text: &str) -> Option<String> {
-        let re = regex::Regex::new(pattern).ok()?;
+        if enforce_input_limit("regex text", text.len(), MAX_REGEX_TEXT_BYTES).is_err() {
+            return None;
+        }
+        let re = compile_plugin_regex(pattern).ok()?;
         let caps = re.captures(text)?;
         caps.get(1)
             .or_else(|| caps.get(0))
@@ -288,7 +345,10 @@ impl HostApi {
     }
 
     pub fn regex_match_all(&self, pattern: &str, text: &str) -> Vec<String> {
-        let re = match regex::Regex::new(pattern) {
+        if enforce_input_limit("regex text", text.len(), MAX_REGEX_TEXT_BYTES).is_err() {
+            return Vec::new();
+        }
+        let re = match compile_plugin_regex(pattern) {
             Ok(r) => r,
             Err(_) => return Vec::new(),
         };
@@ -542,6 +602,7 @@ impl HostApi {
 
     pub fn html_query_all(&self, html: &str, selector: &str) -> Result<Vec<String>, String> {
         use scraper::{Html, Selector};
+        enforce_input_limit("html", html.len(), MAX_HTML_BYTES)?;
         let doc = Html::parse_document(html);
         let sel =
             Selector::parse(selector).map_err(|e| format!("Invalid CSS selector: {e:?}"))?;
@@ -550,6 +611,7 @@ impl HostApi {
 
     pub fn html_query_text(&self, html: &str, selector: &str) -> Result<Option<String>, String> {
         use scraper::{Html, Selector};
+        enforce_input_limit("html", html.len(), MAX_HTML_BYTES)?;
         let doc = Html::parse_document(html);
         let sel =
             Selector::parse(selector).map_err(|e| format!("Invalid CSS selector: {e:?}"))?;
@@ -566,6 +628,7 @@ impl HostApi {
         attr: &str,
     ) -> Result<Option<String>, String> {
         use scraper::{Html, Selector};
+        enforce_input_limit("html", html.len(), MAX_HTML_BYTES)?;
         let doc = Html::parse_document(html);
         let sel =
             Selector::parse(selector).map_err(|e| format!("Invalid CSS selector: {e:?}"))?;
@@ -577,6 +640,9 @@ impl HostApi {
 
     pub fn html_search_meta(&self, html: &str, names: &[String]) -> Option<String> {
         use scraper::{Html, Selector};
+        if enforce_input_limit("html", html.len(), MAX_HTML_BYTES).is_err() {
+            return None;
+        }
         let doc = Html::parse_document(html);
         let selectors = ["meta[name='{name}']", "meta[property='{name}']"];
         for name in names {
@@ -597,6 +663,9 @@ impl HostApi {
 
     pub fn html_extract_title(&self, html: &str) -> Option<String> {
         use scraper::{Html, Selector};
+        if enforce_input_limit("html", html.len(), MAX_HTML_BYTES).is_err() {
+            return None;
+        }
         let doc = Html::parse_document(html);
         let sel = Selector::parse("title").ok()?;
         doc.select(&sel)
@@ -606,6 +675,9 @@ impl HostApi {
 
     pub fn html_hidden_inputs(&self, html: &str) -> HashMap<String, String> {
         use scraper::{Html, Selector};
+        if enforce_input_limit("html", html.len(), MAX_HTML_BYTES).is_err() {
+            return HashMap::new();
+        }
         let doc = Html::parse_document(html);
         let sel = match Selector::parse("input[type='hidden']") {
             Ok(s) => s,
@@ -621,7 +693,10 @@ impl HostApi {
     }
 
     pub fn search_json(&self, start_pattern: &str, html: &str) -> Option<String> {
-        let re = regex::Regex::new(start_pattern).ok()?;
+        if enforce_input_limit("search_json html", html.len(), MAX_HTML_BYTES).is_err() {
+            return None;
+        }
+        let re = compile_plugin_regex(start_pattern).ok()?;
         let m = re.find(html)?;
         let rest = &html[m.end()..];
 
@@ -672,18 +747,27 @@ impl HostApi {
     // --- Additional regex helpers ---
 
     pub fn regex_replace(&self, pattern: &str, text: &str, replacement: &str) -> Option<String> {
-        let re = regex::Regex::new(pattern).ok()?;
+        if enforce_input_limit("regex text", text.len(), MAX_REGEX_TEXT_BYTES).is_err() {
+            return None;
+        }
+        let re = compile_plugin_regex(pattern).ok()?;
         Some(re.replace_all(text, replacement).into_owned())
     }
 
     pub fn regex_test(&self, pattern: &str, text: &str) -> bool {
-        regex::Regex::new(pattern)
+        if enforce_input_limit("regex text", text.len(), MAX_REGEX_TEXT_BYTES).is_err() {
+            return false;
+        }
+        compile_plugin_regex(pattern)
             .map(|re| re.is_match(text))
             .unwrap_or(false)
     }
 
     pub fn regex_split(&self, pattern: &str, text: &str) -> Vec<String> {
-        match regex::Regex::new(pattern) {
+        if enforce_input_limit("regex text", text.len(), MAX_REGEX_TEXT_BYTES).is_err() {
+            return vec![text.to_string()];
+        }
+        match compile_plugin_regex(pattern) {
             Ok(re) => re.split(text).map(|s| s.to_string()).collect(),
             Err(_) => vec![text.to_string()],
         }
@@ -820,6 +904,7 @@ impl HostApi {
         attr: &str,
     ) -> Result<Vec<String>, String> {
         use scraper::{Html, Selector};
+        enforce_input_limit("html", html.len(), MAX_HTML_BYTES)?;
         let doc = Html::parse_document(html);
         let sel =
             Selector::parse(selector).map_err(|e| format!("Invalid CSS selector: {e:?}"))?;
@@ -1745,6 +1830,7 @@ pub fn register_host_api(
 // --- Base64 helpers ---
 
 fn base64_decode_bytes(input: &str) -> Result<Vec<u8>, String> {
+    enforce_input_limit("base64 input", input.len(), MAX_BASE64_INPUT_BYTES)?;
     let alphabet = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
     let mut table = [0u8; 256];
     for (i, &c) in alphabet.iter().enumerate() {
@@ -2156,5 +2242,62 @@ mod tests {
             api.html_query_attr(html, "a", "href").unwrap(),
             Some("/file.zip".to_string())
         );
+    }
+
+    // --- Resource-limit regression tests (audit #11) ---
+
+    #[test]
+    fn regex_helpers_reject_oversize_text() {
+        let api = HostApi::new(20);
+        let huge = "a".repeat(MAX_REGEX_TEXT_BYTES + 1);
+        assert_eq!(huge.len(), MAX_REGEX_TEXT_BYTES + 1, "sanity");
+        // Match returns None instead of grinding through gigabytes.
+        assert!(api.regex_match(r"a+", &huge).is_none());
+        // match_all degrades gracefully to an empty result.
+        assert!(api.regex_match_all(r"a+", &huge).is_empty());
+        // replace returns None when the text is oversized. Arg order is
+        // regex_replace(pattern, text, replacement) — putting the huge
+        // string in the replacement slot is a different test.
+        let replaced = api.regex_replace(r"a", &huge, "b");
+        assert!(
+            replaced.is_none(),
+            "regex_replace must short-circuit on oversize input"
+        );
+        // test returns false.
+        assert!(!api.regex_test(r"a", &huge));
+        // split returns the input untouched.
+        let split = api.regex_split(r"a", &huge);
+        assert_eq!(split.len(), 1);
+        assert_eq!(split[0].len(), huge.len());
+    }
+
+    #[test]
+    fn regex_helpers_reject_oversize_pattern() {
+        // A pathologically long pattern is rejected at compile time so we
+        // never even try to run it.
+        let api = HostApi::new(20);
+        let pattern = "a".repeat(MAX_REGEX_PATTERN_BYTES + 1);
+        assert_eq!(api.regex_match(&pattern, "aaaa"), None);
+    }
+
+    #[test]
+    fn html_helpers_reject_oversize_input() {
+        let api = HostApi::new(20);
+        let huge = "<p>".repeat(MAX_HTML_BYTES); // > 8 MiB
+        assert!(api.html_query_all(&huge, "p").is_err());
+        assert!(api.html_query_text(&huge, "p").is_err());
+        assert!(
+            api.html_query_attr(&huge, "p", "x").is_err()
+        );
+        assert_eq!(api.html_extract_title(&huge), None);
+        assert!(api.html_hidden_inputs(&huge).is_empty());
+    }
+
+    #[test]
+    fn base64_decode_rejects_oversize_input() {
+        let api = HostApi::new(20);
+        let huge = "A".repeat(MAX_BASE64_INPUT_BYTES + 1);
+        let err = api.base64_decode(&huge).expect_err("must reject");
+        assert!(err.contains("base64 input too large"), "msg: {err}");
     }
 }

--- a/crates/plugin-runtime/src/host_api.rs
+++ b/crates/plugin-runtime/src/host_api.rs
@@ -406,7 +406,12 @@ impl HostApi {
         Ok(hex::encode(mac.finalize().into_bytes()))
     }
 
-    pub fn aes_decrypt_cbc(&self, data_b64: &str, key_hex: &str, iv_hex: &str) -> Result<String, String> {
+    pub fn aes_decrypt_cbc(
+        &self,
+        data_b64: &str,
+        key_hex: &str,
+        iv_hex: &str,
+    ) -> Result<String, String> {
         use aes::cipher::{BlockDecryptMut, KeyIvInit};
         type Aes128CbcDec = cbc::Decryptor<aes::Aes128>;
 
@@ -422,8 +427,8 @@ impl HostApi {
         }
 
         let mut buf = data.clone();
-        let decryptor = Aes128CbcDec::new_from_slices(&key, &iv)
-            .map_err(|e| format!("AES init error: {e}"))?;
+        let decryptor =
+            Aes128CbcDec::new_from_slices(&key, &iv).map_err(|e| format!("AES init error: {e}"))?;
         let decrypted = decryptor
             .decrypt_padded_mut::<aes::cipher::block_padding::Pkcs7>(&mut buf)
             .map_err(|e| format!("AES decrypt error: {e}"))?;
@@ -431,7 +436,12 @@ impl HostApi {
         Ok(base64_encode_bytes(decrypted))
     }
 
-    pub fn aes_encrypt_cbc(&self, data_b64: &str, key_hex: &str, iv_hex: &str) -> Result<String, String> {
+    pub fn aes_encrypt_cbc(
+        &self,
+        data_b64: &str,
+        key_hex: &str,
+        iv_hex: &str,
+    ) -> Result<String, String> {
         use aes::cipher::{BlockEncryptMut, KeyIvInit};
         type Aes128CbcEnc = cbc::Encryptor<aes::Aes128>;
 
@@ -452,8 +462,8 @@ impl HostApi {
         let mut buf = vec![0u8; padded_len];
         buf[..data.len()].copy_from_slice(&data);
 
-        let encryptor = Aes128CbcEnc::new_from_slices(&key, &iv)
-            .map_err(|e| format!("AES init error: {e}"))?;
+        let encryptor =
+            Aes128CbcEnc::new_from_slices(&key, &iv).map_err(|e| format!("AES init error: {e}"))?;
         let encrypted = encryptor
             .encrypt_padded_mut::<aes::cipher::block_padding::Pkcs7>(&mut buf, data.len())
             .map_err(|e| format!("AES encrypt error: {e}"))?;
@@ -474,12 +484,7 @@ impl HostApi {
     /// map after the proposed write; an oversize write is rejected without
     /// mutating state. Returns `Err` with a human-readable message on quota
     /// breach so the JS binding can surface it as a thrown exception.
-    pub async fn storage_set(
-        &self,
-        plugin_id: &str,
-        key: &str,
-        value: &str,
-    ) -> Result<(), String> {
+    pub async fn storage_set(&self, plugin_id: &str, key: &str, value: &str) -> Result<(), String> {
         let mut storage = self.storage.lock().await;
         let map = storage.entry(plugin_id.to_string()).or_default();
 
@@ -604,8 +609,7 @@ impl HostApi {
         use scraper::{Html, Selector};
         enforce_input_limit("html", html.len(), MAX_HTML_BYTES)?;
         let doc = Html::parse_document(html);
-        let sel =
-            Selector::parse(selector).map_err(|e| format!("Invalid CSS selector: {e:?}"))?;
+        let sel = Selector::parse(selector).map_err(|e| format!("Invalid CSS selector: {e:?}"))?;
         Ok(doc.select(&sel).map(|el| el.html()).collect())
     }
 
@@ -613,8 +617,7 @@ impl HostApi {
         use scraper::{Html, Selector};
         enforce_input_limit("html", html.len(), MAX_HTML_BYTES)?;
         let doc = Html::parse_document(html);
-        let sel =
-            Selector::parse(selector).map_err(|e| format!("Invalid CSS selector: {e:?}"))?;
+        let sel = Selector::parse(selector).map_err(|e| format!("Invalid CSS selector: {e:?}"))?;
         Ok(doc
             .select(&sel)
             .next()
@@ -630,8 +633,7 @@ impl HostApi {
         use scraper::{Html, Selector};
         enforce_input_limit("html", html.len(), MAX_HTML_BYTES)?;
         let doc = Html::parse_document(html);
-        let sel =
-            Selector::parse(selector).map_err(|e| format!("Invalid CSS selector: {e:?}"))?;
+        let sel = Selector::parse(selector).map_err(|e| format!("Invalid CSS selector: {e:?}"))?;
         Ok(doc
             .select(&sel)
             .next()
@@ -653,9 +655,9 @@ impl HostApi {
                         .select(&sel)
                         .next()
                         .and_then(|el| el.value().attr("content"))
-                    {
-                        return Some(content.to_string());
-                    }
+                {
+                    return Some(content.to_string());
+                }
             }
         }
         None
@@ -906,8 +908,7 @@ impl HostApi {
         use scraper::{Html, Selector};
         enforce_input_limit("html", html.len(), MAX_HTML_BYTES)?;
         let doc = Html::parse_document(html);
-        let sel =
-            Selector::parse(selector).map_err(|e| format!("Invalid CSS selector: {e:?}"))?;
+        let sel = Selector::parse(selector).map_err(|e| format!("Invalid CSS selector: {e:?}"))?;
         Ok(doc
             .select(&sel)
             .filter_map(|el| el.value().attr(attr).map(|s| s.to_string()))
@@ -1269,7 +1270,9 @@ pub fn register_host_api(
     amigo
         .set(
             "md5",
-            Function::new(ctx.clone(), move |input: String| -> String { h.md5(&input) }),
+            Function::new(ctx.clone(), move |input: String| -> String {
+                h.md5(&input)
+            }),
         )
         .map_err(|e| crate::Error::Execution(e.to_string()))?;
 
@@ -1277,7 +1280,9 @@ pub fn register_host_api(
     amigo
         .set(
             "sha1",
-            Function::new(ctx.clone(), move |input: String| -> String { h.sha1(&input) }),
+            Function::new(ctx.clone(), move |input: String| -> String {
+                h.sha1(&input)
+            }),
         )
         .map_err(|e| crate::Error::Execution(e.to_string()))?;
 
@@ -1468,10 +1473,9 @@ pub fn register_host_api(
     amigo
         .set(
             "urlFilename",
-            Function::new(
-                ctx.clone(),
-                move |url: String| -> Option<String> { h.url_filename(&url) },
-            ),
+            Function::new(ctx.clone(), move |url: String| -> Option<String> {
+                h.url_filename(&url)
+            }),
         )
         .map_err(|e| crate::Error::Execution(e.to_string()))?;
 
@@ -1591,10 +1595,9 @@ pub fn register_host_api(
     amigo
         .set(
             "regexTest",
-            Function::new(
-                ctx.clone(),
-                move |pattern: String, text: String| -> bool { h.regex_test(&pattern, &text) },
-            ),
+            Function::new(ctx.clone(), move |pattern: String, text: String| -> bool {
+                h.regex_test(&pattern, &text)
+            }),
         )
         .map_err(|e| crate::Error::Execution(e.to_string()))?;
 
@@ -1617,10 +1620,9 @@ pub fn register_host_api(
     amigo
         .set(
             "parseDuration",
-            Function::new(
-                ctx.clone(),
-                move |input: String| -> Option<f64> { h.parse_duration(&input) },
-            ),
+            Function::new(ctx.clone(), move |input: String| -> Option<f64> {
+                h.parse_duration(&input)
+            }),
         )
         .map_err(|e| crate::Error::Execution(e.to_string()))?;
 
@@ -1704,8 +1706,7 @@ pub fn register_host_api(
                     let result = tokio::task::block_in_place(|| {
                         rt.block_on(async { h.http_get_binary(&url, headers).await })
                     });
-                    result
-                        .map_err(|e| rquickjs::Error::new_from_js_message("string", "Error", &e))
+                    result.map_err(|e| rquickjs::Error::new_from_js_message("string", "Error", &e))
                 },
             ),
         )
@@ -1726,8 +1727,7 @@ pub fn register_host_api(
                     let result = tokio::task::block_in_place(|| {
                         rt.block_on(async { h.http_follow_redirects(&url, headers).await })
                     });
-                    result
-                        .map_err(|e| rquickjs::Error::new_from_js_message("string", "Error", &e))
+                    result.map_err(|e| rquickjs::Error::new_from_js_message("string", "Error", &e))
                 },
             ),
         )
@@ -1739,10 +1739,7 @@ pub fn register_host_api(
             "__rawHtmlQueryAllAttrs",
             Function::new(
                 ctx.clone(),
-                move |html: String,
-                      selector: String,
-                      attr: String|
-                      -> rquickjs::Result<String> {
+                move |html: String, selector: String, attr: String| -> rquickjs::Result<String> {
                     h.html_query_all_attrs(&html, &selector, &attr)
                         .map(|v| serde_json::to_string(&v).unwrap_or_else(|_| "[]".into()))
                         .map_err(|e| rquickjs::Error::new_from_js_message("string", "Error", &e))
@@ -1767,9 +1764,7 @@ pub fn register_host_api(
                     let ct = captcha_type.unwrap_or_else(|| "image".to_string());
                     let rt = tokio::runtime::Handle::current();
                     let result = tokio::task::block_in_place(|| {
-                        rt.block_on(async {
-                            h.solve_captcha(&pid, "", &image_url, &ct).await
-                        })
+                        rt.block_on(async { h.solve_captcha(&pid, "", &image_url, &ct).await })
                     });
                     result.map_err(|e| rquickjs::Error::new_from_js_message("string", "Error", &e))
                 },
@@ -1820,9 +1815,8 @@ pub fn register_host_api(
 
     // Inject JS shim layer: wraps __raw* functions to return objects instead of JSON strings.
     // This keeps the Rust→JS boundary simple (string returns) while giving plugins a clean API.
-    ctx.eval::<JsValue<'_>, _>(JS_SHIM).map_err(|e| {
-        crate::Error::Execution(format!("Failed to inject JS shim: {e}"))
-    })?;
+    ctx.eval::<JsValue<'_>, _>(JS_SHIM)
+        .map_err(|e| crate::Error::Execution(format!("Failed to inject JS shim: {e}")))?;
 
     Ok(())
 }
@@ -1961,7 +1955,9 @@ mod tests {
         // IPv4-mapped loopback
         assert!(is_blocked_ip("::ffff:127.0.0.1".parse::<IpAddr>().unwrap()));
         // Public v6 is allowed.
-        assert!(!is_blocked_ip("2606:4700:4700::1111".parse::<IpAddr>().unwrap()));
+        assert!(!is_blocked_ip(
+            "2606:4700:4700::1111".parse::<IpAddr>().unwrap()
+        ));
     }
 
     #[tokio::test]
@@ -1987,7 +1983,10 @@ mod tests {
     #[tokio::test]
     async fn ssrf_rejects_non_http_scheme() {
         let api = HostApi::new(20);
-        let err = api.check_url_allowed("file:///etc/passwd").await.unwrap_err();
+        let err = api
+            .check_url_allowed("file:///etc/passwd")
+            .await
+            .unwrap_err();
         assert!(err.contains("scheme not allowed"), "{err}");
     }
 
@@ -2047,7 +2046,8 @@ mod tests {
         api.set_cookie("attacker", "real-debrid.com", "auth", "secret-B")
             .await;
         assert_eq!(
-            api.get_cookie("real-debrid", "real-debrid.com", "auth").await,
+            api.get_cookie("real-debrid", "real-debrid.com", "auth")
+                .await,
             Some("secret-A".to_string())
         );
         assert_eq!(
@@ -2061,7 +2061,8 @@ mod tests {
             None
         );
         assert_eq!(
-            api.get_cookie("real-debrid", "real-debrid.com", "auth").await,
+            api.get_cookie("real-debrid", "real-debrid.com", "auth")
+                .await,
             Some("secret-A".to_string())
         );
     }
@@ -2157,7 +2158,10 @@ mod tests {
     #[test]
     fn test_sha1() {
         let api = HostApi::new(20);
-        assert_eq!(api.sha1("hello"), "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d");
+        assert_eq!(
+            api.sha1("hello"),
+            "aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d"
+        );
     }
 
     #[test]
@@ -2217,7 +2221,8 @@ mod tests {
     fn test_url_helpers() {
         let api = HostApi::new(20);
         assert_eq!(
-            api.url_resolve("https://example.com/page/", "../file.zip").unwrap(),
+            api.url_resolve("https://example.com/page/", "../file.zip")
+                .unwrap(),
             "https://example.com/file.zip"
         );
         assert_eq!(
@@ -2286,9 +2291,7 @@ mod tests {
         let huge = "<p>".repeat(MAX_HTML_BYTES); // > 8 MiB
         assert!(api.html_query_all(&huge, "p").is_err());
         assert!(api.html_query_text(&huge, "p").is_err());
-        assert!(
-            api.html_query_attr(&huge, "p", "x").is_err()
-        );
+        assert!(api.html_query_attr(&huge, "p", "x").is_err());
         assert_eq!(api.html_extract_title(&huge), None);
         assert!(api.html_hidden_inputs(&huge).is_empty());
     }

--- a/crates/plugin-runtime/src/host_api.rs
+++ b/crates/plugin-runtime/src/host_api.rs
@@ -31,12 +31,19 @@ pub struct HostApi {
     storage: Arc<Mutex<HashMap<String, HashMap<String, String>>>>,
     request_count: Arc<Mutex<u32>>,
     max_requests: u32,
+    /// Per-plugin storage quota (bytes). Counted across all `(key, value)`
+    /// pairs of a single plugin's storage map.
+    max_storage_bytes: u64,
     notify_callback: Option<NotifyCallback>,
     captcha_callback: Option<CaptchaSolveCallback>,
     /// When false, reject plugin HTTP requests whose resolved IP is loopback,
     /// private (RFC1918), link-local, CGNAT, or otherwise non-public.
     allow_private_network: bool,
 }
+
+/// Default per-plugin storage quota when constructed via [`HostApi::new`]
+/// without a SandboxLimits. Matches `SandboxLimits::default().max_storage_bytes`.
+const DEFAULT_MAX_STORAGE_BYTES: u64 = 1024 * 1024;
 
 impl HostApi {
     pub fn new(max_requests: u32) -> Self {
@@ -49,6 +56,7 @@ impl HostApi {
             storage: Arc::new(Mutex::new(HashMap::new())),
             request_count: Arc::new(Mutex::new(0)),
             max_requests,
+            max_storage_bytes: DEFAULT_MAX_STORAGE_BYTES,
             notify_callback: None,
             captcha_callback: None,
             allow_private_network: false,
@@ -60,6 +68,7 @@ impl HostApi {
     pub fn from_sandbox(limits: &crate::sandbox::SandboxLimits) -> Self {
         let mut api = Self::new(limits.max_http_requests);
         api.allow_private_network = limits.allow_private_network;
+        api.max_storage_bytes = limits.max_storage_bytes;
         api
     }
 
@@ -382,12 +391,40 @@ impl HostApi {
         storage.get(plugin_id)?.get(key).cloned()
     }
 
-    pub async fn storage_set(&self, plugin_id: &str, key: &str, value: &str) {
+    /// Persist `value` under `(plugin_id, key)`. Enforces the per-plugin
+    /// quota configured via [`SandboxLimits::max_storage_bytes`]. The total
+    /// is computed across all `(key, value)` byte lengths in this plugin's
+    /// map after the proposed write; an oversize write is rejected without
+    /// mutating state. Returns `Err` with a human-readable message on quota
+    /// breach so the JS binding can surface it as a thrown exception.
+    pub async fn storage_set(
+        &self,
+        plugin_id: &str,
+        key: &str,
+        value: &str,
+    ) -> Result<(), String> {
         let mut storage = self.storage.lock().await;
-        storage
-            .entry(plugin_id.to_string())
-            .or_default()
-            .insert(key.to_string(), value.to_string());
+        let map = storage.entry(plugin_id.to_string()).or_default();
+
+        let old_size = map
+            .get(key)
+            .map(|v| v.len() as u64 + key.len() as u64)
+            .unwrap_or(0);
+        let new_pair = key.len() as u64 + value.len() as u64;
+        let mut total: u64 = map
+            .iter()
+            .map(|(k, v)| k.len() as u64 + v.len() as u64)
+            .sum();
+        total = total.saturating_sub(old_size).saturating_add(new_pair);
+
+        if total > self.max_storage_bytes {
+            return Err(format!(
+                "storage quota exceeded for plugin '{plugin_id}': {total} > {} bytes",
+                self.max_storage_bytes
+            ));
+        }
+        map.insert(key.to_string(), value.to_string());
+        Ok(())
     }
 
     pub async fn storage_delete(&self, plugin_id: &str, key: &str) {
@@ -1255,14 +1292,18 @@ pub fn register_host_api(
     amigo
         .set(
             "storageSet",
-            Function::new(ctx.clone(), move |key: String, value: String| {
-                let h = h.clone();
-                let pid = pid.clone();
-                let rt = tokio::runtime::Handle::current();
-                tokio::task::block_in_place(|| {
-                    rt.block_on(async { h.storage_set(&pid, &key, &value).await })
-                });
-            }),
+            Function::new(
+                ctx.clone(),
+                move |key: String, value: String| -> rquickjs::Result<()> {
+                    let h = h.clone();
+                    let pid = pid.clone();
+                    let rt = tokio::runtime::Handle::current();
+                    tokio::task::block_in_place(|| {
+                        rt.block_on(async { h.storage_set(&pid, &key, &value).await })
+                    })
+                    .map_err(|e| rquickjs::Error::new_from_js_message("string", "Error", &e))
+                },
+            ),
         )
         .map_err(|e| crate::Error::Execution(e.to_string()))?;
 
@@ -1882,13 +1923,82 @@ mod tests {
     #[tokio::test]
     async fn test_storage() {
         let api = HostApi::new(20);
-        api.storage_set("test-plugin", "key1", "value1").await;
+        api.storage_set("test-plugin", "key1", "value1")
+            .await
+            .expect("write within quota must succeed");
         assert_eq!(
             api.storage_get("test-plugin", "key1").await,
             Some("value1".to_string())
         );
         api.storage_delete("test-plugin", "key1").await;
         assert_eq!(api.storage_get("test-plugin", "key1").await, None);
+    }
+
+    #[tokio::test]
+    async fn storage_quota_rejects_oversized_write() {
+        // 1 KiB quota — we should be able to set a value just under the
+        // limit, then fail to grow past it.
+        let limits = crate::sandbox::SandboxLimits {
+            max_storage_bytes: 1024,
+            ..Default::default()
+        };
+        let api = HostApi::from_sandbox(&limits);
+
+        // Fill with ~900 bytes (key+value), still under quota.
+        let big = "x".repeat(900);
+        api.storage_set("p", "big", &big)
+            .await
+            .expect("first write fits");
+
+        // Try to push the total above 1 KiB with a 200-byte value.
+        let err = api
+            .storage_set("p", "extra", &"y".repeat(200))
+            .await
+            .expect_err("second write must exceed quota");
+        assert!(err.contains("storage quota exceeded"), "msg: {err}");
+
+        // The rejected write must not have mutated state.
+        assert_eq!(api.storage_get("p", "extra").await, None);
+        assert_eq!(api.storage_get("p", "big").await, Some(big));
+    }
+
+    #[tokio::test]
+    async fn storage_quota_replacing_existing_key_uses_delta() {
+        // Replacing an existing key must charge only the *delta*, not the
+        // full new value, otherwise plugins can't shrink an oversized blob
+        // even when freeing space is the goal.
+        let limits = crate::sandbox::SandboxLimits {
+            max_storage_bytes: 1024,
+            ..Default::default()
+        };
+        let api = HostApi::from_sandbox(&limits);
+        api.storage_set("p", "k", &"a".repeat(900))
+            .await
+            .expect("initial 900-byte write fits");
+        // Overwriting with the same size must succeed.
+        api.storage_set("p", "k", &"b".repeat(900))
+            .await
+            .expect("same-size overwrite must succeed");
+        // Shrinking is also fine.
+        api.storage_set("p", "k", &"c".repeat(10))
+            .await
+            .expect("shrinking write must succeed");
+    }
+
+    #[tokio::test]
+    async fn storage_quota_isolated_per_plugin() {
+        let limits = crate::sandbox::SandboxLimits {
+            max_storage_bytes: 1024,
+            ..Default::default()
+        };
+        let api = HostApi::from_sandbox(&limits);
+        api.storage_set("plugin-a", "k", &"a".repeat(900))
+            .await
+            .expect("a fits");
+        // Plugin B has its own quota — must still be able to write.
+        api.storage_set("plugin-b", "k", &"b".repeat(900))
+            .await
+            .expect("b has its own quota");
     }
 
     #[test]

--- a/crates/plugin-runtime/src/host_api.rs
+++ b/crates/plugin-runtime/src/host_api.rs
@@ -23,11 +23,19 @@ pub type CaptchaSolveCallback =
 pub type CaptchaFuture =
     std::pin::Pin<Box<dyn std::future::Future<Output = Result<String, String>> + Send>>;
 
+/// Per-plugin cookie jars: `plugin_id → domain → name → value`.
+type CookieJars = HashMap<String, HashMap<String, HashMap<String, String>>>;
+
 /// Shared state for the Host API, passed into every plugin call.
 #[derive(Clone)]
 pub struct HostApi {
     http_client: reqwest::Client,
-    cookies: Arc<Mutex<HashMap<String, HashMap<String, String>>>>,
+    /// Per-plugin cookie jars (`plugin_id → domain → name → value`). The
+    /// outer key is the calling plugin's id, set at register-time via
+    /// `register_host_api` and not under JS control, so
+    /// `getCookie("real-debrid.com", "auth")` from plugin A cannot read a
+    /// cookie that plugin B stashed under the same domain.
+    cookies: Arc<Mutex<CookieJars>>,
     storage: Arc<Mutex<HashMap<String, HashMap<String, String>>>>,
     request_count: Arc<Mutex<u32>>,
     max_requests: u32,
@@ -241,23 +249,32 @@ impl HostApi {
     }
 
     // --- Cookie management ---
+    //
+    // Each plugin sees its own private cookie jar. The plugin_id argument is
+    // captured at register-time by the JS bindings (see register_host_api)
+    // so a malicious plugin cannot pass a different plugin_id from JS to
+    // read another plugin's cookies.
 
-    pub async fn set_cookie(&self, domain: &str, name: &str, value: &str) {
+    pub async fn set_cookie(&self, plugin_id: &str, domain: &str, name: &str, value: &str) {
         let mut cookies = self.cookies.lock().await;
         cookies
+            .entry(plugin_id.to_string())
+            .or_default()
             .entry(domain.to_string())
             .or_default()
             .insert(name.to_string(), value.to_string());
     }
 
-    pub async fn get_cookie(&self, domain: &str, name: &str) -> Option<String> {
+    pub async fn get_cookie(&self, plugin_id: &str, domain: &str, name: &str) -> Option<String> {
         let cookies = self.cookies.lock().await;
-        cookies.get(domain)?.get(name).cloned()
+        cookies.get(plugin_id)?.get(domain)?.get(name).cloned()
     }
 
-    pub async fn clear_cookies(&self, domain: &str) {
+    pub async fn clear_cookies(&self, plugin_id: &str, domain: &str) {
         let mut cookies = self.cookies.lock().await;
-        cookies.remove(domain);
+        if let Some(jar) = cookies.get_mut(plugin_id) {
+            jar.remove(domain);
+        }
     }
 
     // --- Parsing helpers ---
@@ -1054,6 +1071,10 @@ pub fn register_host_api(
         .map_err(|e| crate::Error::Execution(e.to_string()))?;
 
     // --- Cookies ---
+    // plugin_id is captured at register-time and is NOT exposed to JS, so a
+    // plugin's setCookie / getCookie / clearCookies always operate on its
+    // own private cookie jar.
+    let pid = plugin_id.to_string();
     let h = host.clone();
     amigo
         .set(
@@ -1062,15 +1083,17 @@ pub fn register_host_api(
                 ctx.clone(),
                 move |domain: String, name: String, value: String| {
                     let h = h.clone();
+                    let pid = pid.clone();
                     let rt = tokio::runtime::Handle::current();
                     tokio::task::block_in_place(|| {
-                        rt.block_on(async { h.set_cookie(&domain, &name, &value).await })
+                        rt.block_on(async { h.set_cookie(&pid, &domain, &name, &value).await })
                     });
                 },
             ),
         )
         .map_err(|e| crate::Error::Execution(e.to_string()))?;
 
+    let pid = plugin_id.to_string();
     let h = host.clone();
     amigo
         .set(
@@ -1079,24 +1102,27 @@ pub fn register_host_api(
                 ctx.clone(),
                 move |domain: String, name: String| -> rquickjs::Result<Option<String>> {
                     let h = h.clone();
+                    let pid = pid.clone();
                     let rt = tokio::runtime::Handle::current();
                     Ok(tokio::task::block_in_place(|| {
-                        rt.block_on(async { h.get_cookie(&domain, &name).await })
+                        rt.block_on(async { h.get_cookie(&pid, &domain, &name).await })
                     }))
                 },
             ),
         )
         .map_err(|e| crate::Error::Execution(e.to_string()))?;
 
+    let pid = plugin_id.to_string();
     let h = host.clone();
     amigo
         .set(
             "clearCookies",
             Function::new(ctx.clone(), move |domain: String| {
                 let h = h.clone();
+                let pid = pid.clone();
                 let rt = tokio::runtime::Handle::current();
                 tokio::task::block_in_place(|| {
-                    rt.block_on(async { h.clear_cookies(&domain).await })
+                    rt.block_on(async { h.clear_cookies(&pid, &domain).await })
                 });
             }),
         )
@@ -1911,13 +1937,47 @@ mod tests {
     #[tokio::test]
     async fn test_cookie_management() {
         let api = HostApi::new(20);
-        api.set_cookie("example.com", "session", "abc123").await;
+        api.set_cookie("plugin-x", "example.com", "session", "abc123")
+            .await;
         assert_eq!(
-            api.get_cookie("example.com", "session").await,
+            api.get_cookie("plugin-x", "example.com", "session").await,
             Some("abc123".to_string())
         );
-        api.clear_cookies("example.com").await;
-        assert_eq!(api.get_cookie("example.com", "session").await, None);
+        api.clear_cookies("plugin-x", "example.com").await;
+        assert_eq!(
+            api.get_cookie("plugin-x", "example.com", "session").await,
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn cookies_isolated_between_plugins() {
+        // The previous shared-jar implementation let plugin B read a
+        // cookie that plugin A had stashed under the same domain. Each
+        // plugin must now see only its own cookies.
+        let api = HostApi::new(20);
+        api.set_cookie("real-debrid", "real-debrid.com", "auth", "secret-A")
+            .await;
+        api.set_cookie("attacker", "real-debrid.com", "auth", "secret-B")
+            .await;
+        assert_eq!(
+            api.get_cookie("real-debrid", "real-debrid.com", "auth").await,
+            Some("secret-A".to_string())
+        );
+        assert_eq!(
+            api.get_cookie("attacker", "real-debrid.com", "auth").await,
+            Some("secret-B".to_string())
+        );
+        // Clearing one plugin's jar must not touch the other's.
+        api.clear_cookies("attacker", "real-debrid.com").await;
+        assert_eq!(
+            api.get_cookie("attacker", "real-debrid.com", "auth").await,
+            None
+        );
+        assert_eq!(
+            api.get_cookie("real-debrid", "real-debrid.com", "auth").await,
+            Some("secret-A".to_string())
+        );
     }
 
     #[tokio::test]

--- a/crates/plugin-runtime/src/loader.rs
+++ b/crates/plugin-runtime/src/loader.rs
@@ -13,7 +13,9 @@ use tracing::{debug, info, warn};
 use crate::engine::{EngineConfig, PluginContext, PluginEngine};
 use crate::host_api::{self, HostApi};
 use crate::sandbox::SandboxLimits;
-use crate::types::{DownloadPackage, PluginMeta, PluginType, PostProcessContext, PostProcessResult};
+use crate::types::{
+    DownloadPackage, PluginMeta, PluginType, PostProcessContext, PostProcessResult,
+};
 
 /// A loaded, ready-to-execute plugin.
 struct LoadedPlugin {
@@ -91,9 +93,10 @@ impl PluginLoader {
                 for sub_entry in sub_entries.flatten() {
                     let sub_dir = sub_entry.path();
                     if sub_dir.is_dir()
-                        && let Some(path) = find_plugin_entry(&sub_dir) {
-                            self.try_load_plugin(&path, &mut metas).await;
-                        }
+                        && let Some(path) = find_plugin_entry(&sub_dir)
+                    {
+                        self.try_load_plugin(&path, &mut metas).await;
+                    }
                 }
             }
         }

--- a/crates/plugin-runtime/src/registry.rs
+++ b/crates/plugin-runtime/src/registry.rs
@@ -14,11 +14,49 @@ use crate::types::PluginMeta;
 
 /// Ed25519 public key of the amigo-labs plugin registry signer.
 ///
-/// This is a **placeholder** — replace with the real project key before the
-/// 1.0 release. Rotate by shipping a new amigo-server version; clients that
-/// haven't updated will reject the new signatures, which is the safer
+/// Injected at compile time from the `AMIGO_REGISTRY_PUBKEY_HEX` environment
+/// variable (64 hex chars). When unset the value falls back to the all-zero
+/// placeholder, which [`RegistryConfig::default`] explicitly rejects so that
+/// signature verification is disabled (with a runtime warning) in dev builds
+/// instead of trusting a forgeable key. `build.rs` refuses to compile a
+/// release build when the env var is unset, so production binaries always
+/// pin a real key. Rotate by shipping a new amigo-server release; clients
+/// that haven't updated will reject the new signatures, which is the safer
 /// failure mode.
-pub const AMIGO_REGISTRY_PUBLIC_KEY: [u8; 32] = [0u8; 32];
+pub const AMIGO_REGISTRY_PUBLIC_KEY: [u8; 32] = registry_pubkey_from_env();
+
+const ZERO_PUBKEY: [u8; 32] = [0u8; 32];
+
+const fn registry_pubkey_from_env() -> [u8; 32] {
+    match option_env!("AMIGO_REGISTRY_PUBKEY_HEX") {
+        Some(hex) => parse_hex32(hex),
+        None => ZERO_PUBKEY,
+    }
+}
+
+const fn parse_hex32(s: &str) -> [u8; 32] {
+    let bytes = s.as_bytes();
+    assert!(
+        bytes.len() == 64,
+        "AMIGO_REGISTRY_PUBKEY_HEX must be 64 hex chars (32-byte Ed25519 public key)"
+    );
+    let mut out = [0u8; 32];
+    let mut i = 0;
+    while i < 32 {
+        out[i] = (hex_nibble(bytes[i * 2]) << 4) | hex_nibble(bytes[i * 2 + 1]);
+        i += 1;
+    }
+    out
+}
+
+const fn hex_nibble(b: u8) -> u8 {
+    match b {
+        b'0'..=b'9' => b - b'0',
+        b'a'..=b'f' => b - b'a' + 10,
+        b'A'..=b'F' => b - b'A' + 10,
+        _ => panic!("AMIGO_REGISTRY_PUBKEY_HEX contains non-hex character"),
+    }
+}
 
 /// Registry index as served from the plugin repository.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -67,11 +105,20 @@ pub struct RegistryConfig {
 
 impl Default for RegistryConfig {
     fn default() -> Self {
+        // If no real key was injected at compile time, refuse to trust the
+        // zero placeholder. Disabling verification with a warning is safer
+        // than verifying against a key whose private half is publicly
+        // derivable.
+        let trusted_signing_key = if AMIGO_REGISTRY_PUBLIC_KEY == ZERO_PUBKEY {
+            None
+        } else {
+            Some(AMIGO_REGISTRY_PUBLIC_KEY)
+        };
         Self {
             index_url: "https://raw.githubusercontent.com/amigo-labs/amigo-downloader-plugins/main/index.json".into(),
             cache_path: Some(PathBuf::from("plugins/index.json")),
             cache_max_age_secs: 24 * 60 * 60, // 24 hours
-            trusted_signing_key: Some(AMIGO_REGISTRY_PUBLIC_KEY),
+            trusted_signing_key,
         }
     }
 }
@@ -527,6 +574,32 @@ mod tests {
         let err =
             verify_ed25519(b"x", "aa", &pk).expect_err("short signature must error");
         assert!(format!("{err}").contains("wrong length"));
+    }
+
+    #[test]
+    fn default_config_disables_verification_when_pubkey_is_zero() {
+        // The default impl must never trust the all-zero placeholder pubkey.
+        // When no real key was injected at compile time the field has to be
+        // None so that fetch_index_remote logs the explicit "verification
+        // DISABLED" warning instead of silently accepting a forgeable signature.
+        if AMIGO_REGISTRY_PUBLIC_KEY == ZERO_PUBKEY {
+            let cfg = RegistryConfig::default();
+            assert!(
+                cfg.trusted_signing_key.is_none(),
+                "default must not trust the zero placeholder"
+            );
+        } else {
+            let cfg = RegistryConfig::default();
+            assert_eq!(cfg.trusted_signing_key, Some(AMIGO_REGISTRY_PUBLIC_KEY));
+        }
+    }
+
+    #[test]
+    fn parse_hex32_round_trip() {
+        let pk = parse_hex32("0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20");
+        assert_eq!(pk[0], 0x01);
+        assert_eq!(pk[15], 0x10);
+        assert_eq!(pk[31], 0x20);
     }
 
     #[test]

--- a/crates/plugin-runtime/src/registry.rs
+++ b/crates/plugin-runtime/src/registry.rs
@@ -130,10 +130,11 @@ pub async fn load_index(
 ) -> Result<RegistryIndex, crate::Error> {
     // Try local cache first
     if let Some(cache_path) = &config.cache_path
-        && let Some(index) = load_cached_index(cache_path, config.cache_max_age_secs) {
-            debug!("Using cached registry index from {:?}", cache_path);
-            return Ok(index);
-        }
+        && let Some(index) = load_cached_index(cache_path, config.cache_max_age_secs)
+    {
+        debug!("Using cached registry index from {:?}", cache_path);
+        return Ok(index);
+    }
 
     // Fetch from remote
     let index = fetch_index_remote(client, config).await?;
@@ -227,9 +228,7 @@ async fn fetch_index_remote(
             verify_ed25519(&raw, &sig_hex, pubkey)?;
             debug!("Registry index signature verified");
         }
-        None => warn!(
-            "Registry signature verification DISABLED — only safe for local development"
-        ),
+        None => warn!("Registry signature verification DISABLED — only safe for local development"),
     }
 
     let index: RegistryIndex = serde_json::from_slice(&raw)
@@ -242,10 +241,7 @@ async fn fetch_index_remote(
 /// Fetch the detached signature file alongside `index.json` (same URL with
 /// a `.sig` suffix). The body is expected to be a hex-encoded Ed25519
 /// signature — 64 bytes / 128 hex chars, optionally trailing whitespace.
-async fn fetch_signature(
-    client: &reqwest::Client,
-    sig_url: &str,
-) -> Result<String, crate::Error> {
+async fn fetch_signature(client: &reqwest::Client, sig_url: &str) -> Result<String, crate::Error> {
     let resp = client
         .get(sig_url)
         .header("User-Agent", "amigo-downloader")
@@ -262,9 +258,9 @@ async fn fetch_signature(
             resp.status()
         )));
     }
-    resp.text().await.map_err(|e| {
-        crate::Error::RegistryUnavailable(format!("signature body unreadable: {e}"))
-    })
+    resp.text()
+        .await
+        .map_err(|e| crate::Error::RegistryUnavailable(format!("signature body unreadable: {e}")))
 }
 
 /// Verify that `payload` carries the Ed25519 signature `sig_hex` produced
@@ -274,9 +270,8 @@ pub fn verify_ed25519(
     sig_hex: &str,
     pubkey: &[u8; 32],
 ) -> Result<(), crate::Error> {
-    let sig_bytes = hex::decode(sig_hex.trim()).map_err(|e| {
-        crate::Error::RegistryUnavailable(format!("signature is not hex: {e}"))
-    })?;
+    let sig_bytes = hex::decode(sig_hex.trim())
+        .map_err(|e| crate::Error::RegistryUnavailable(format!("signature is not hex: {e}")))?;
     if sig_bytes.len() != 64 {
         return Err(crate::Error::RegistryUnavailable(format!(
             "signature has wrong length {} (want 64)",
@@ -286,9 +281,8 @@ pub fn verify_ed25519(
     let mut sig_arr = [0u8; 64];
     sig_arr.copy_from_slice(&sig_bytes);
     let sig = Signature::from_bytes(&sig_arr);
-    let vk = VerifyingKey::from_bytes(pubkey).map_err(|e| {
-        crate::Error::RegistryUnavailable(format!("bad registry pubkey: {e}"))
-    })?;
+    let vk = VerifyingKey::from_bytes(pubkey)
+        .map_err(|e| crate::Error::RegistryUnavailable(format!("bad registry pubkey: {e}")))?;
     vk.verify(payload, &sig).map_err(|_| {
         crate::Error::RegistryUnavailable(
             "registry signature did not verify against the trusted key".into(),
@@ -353,9 +347,10 @@ pub fn suggest_plugin_for_url<'a>(
 ) -> Option<&'a RegistryPlugin> {
     for plugin in &index.plugins {
         if let Ok(re) = regex::Regex::new(&plugin.url_pattern)
-            && re.is_match(url) {
-                return Some(plugin);
-            }
+            && re.is_match(url)
+        {
+            return Some(plugin);
+        }
     }
     None
 }
@@ -571,8 +566,7 @@ mod tests {
     #[test]
     fn verify_ed25519_rejects_short_signature() {
         let pk = [0u8; 32];
-        let err =
-            verify_ed25519(b"x", "aa", &pk).expect_err("short signature must error");
+        let err = verify_ed25519(b"x", "aa", &pk).expect_err("short signature must error");
         assert!(format!("{err}").contains("wrong length"));
     }
 

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -38,6 +38,7 @@ async-trait = { workspace = true }
 argon2 = { workspace = true }
 rand = { workspace = true }
 cookie = "0.18"
+subtle = "2"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -39,6 +39,8 @@ argon2 = { workspace = true }
 rand = { workspace = true }
 cookie = "0.18"
 subtle = "2"
+thiserror = { workspace = true }
+url = "2"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }

--- a/crates/server/src/api.rs
+++ b/crates/server/src/api.rs
@@ -350,14 +350,19 @@ async fn reorder_queue(
 async fn delete_history(
     State(state): State<AppState>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    state.coordinator.storage().clear_history().await.map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse {
-                error: e.to_string(),
-            }),
-        )
-    })?;
+    state
+        .coordinator
+        .storage()
+        .clear_history()
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+        })?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -422,14 +427,14 @@ async fn suggest_plugin(
     if let Ok(index) = index
         && let Some(plugin) =
             amigo_plugin_runtime::registry::suggest_plugin_for_url(&index, &req.url)
-        {
-            return Json(SuggestPluginResponse {
-                found: true,
-                plugin_id: Some(plugin.id.clone()),
-                plugin_name: Some(plugin.name.clone()),
-                install_command: Some(format!("amigo-dl plugins install {}", plugin.id)),
-            });
-        }
+    {
+        return Json(SuggestPluginResponse {
+            found: true,
+            plugin_id: Some(plugin.id.clone()),
+            plugin_name: Some(plugin.name.clone()),
+            install_command: Some(format!("amigo-dl plugins install {}", plugin.id)),
+        });
+    }
 
     Json(SuggestPluginResponse {
         found: false,
@@ -882,9 +887,7 @@ fn apply_secret_passthrough(
     }
 }
 
-async fn get_config(
-    State(state): State<AppState>,
-) -> Json<amigo_core::config::Config> {
+async fn get_config(State(state): State<AppState>) -> Json<amigo_core::config::Config> {
     let config = state.coordinator.config().await;
     Json(redact_config(config))
 }
@@ -902,7 +905,9 @@ async fn put_config(
     new_config.save(&state.config_path).map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse { error: e.to_string() }),
+            Json(ErrorResponse {
+                error: e.to_string(),
+            }),
         )
     })?;
 
@@ -948,12 +953,19 @@ async fn list_rss_feeds(
         return Ok(Json(Vec::new()));
     }
 
-    let rows = state.coordinator.storage().list_rss_feeds().await.map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse { error: e.to_string() }),
-        )
-    })?;
+    let rows = state
+        .coordinator
+        .storage()
+        .list_rss_feeds()
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+        })?;
 
     Ok(Json(
         rows.into_iter()
@@ -1012,12 +1024,19 @@ async fn add_rss_feed(
         created_at: String::new(),
     };
 
-    state.coordinator.storage().insert_rss_feed(&row).await.map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse { error: e.to_string() }),
-        )
-    })?;
+    state
+        .coordinator
+        .storage()
+        .insert_rss_feed(&row)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+        })?;
 
     Ok((
         StatusCode::CREATED,
@@ -1038,12 +1057,19 @@ async fn delete_rss_feed(
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> Result<StatusCode, (StatusCode, Json<ErrorResponse>)> {
-    state.coordinator.storage().delete_rss_feed(&id).await.map_err(|e| {
-        (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(ErrorResponse { error: e.to_string() }),
-        )
-    })?;
+    state
+        .coordinator
+        .storage()
+        .delete_rss_feed(&id)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: e.to_string(),
+                }),
+            )
+        })?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -1214,7 +1240,10 @@ mod config_redact_tests {
     #[test]
     fn redact_replaces_every_secret_field() {
         let redacted = redact_config(config_with_secrets());
-        assert_eq!(redacted.server.api_token.as_deref(), Some(REDACTED_SENTINEL));
+        assert_eq!(
+            redacted.server.api_token.as_deref(),
+            Some(REDACTED_SENTINEL)
+        );
         assert_eq!(
             redacted.server.admin_password_hash.as_deref(),
             Some(REDACTED_SENTINEL)

--- a/crates/server/src/api.rs
+++ b/crates/server/src/api.rs
@@ -794,16 +794,87 @@ async fn set_nzb_watch_dir(
 
 // --- Unified config endpoint ---
 
+/// Sentinel string substituted for secret fields in config responses. The UI
+/// renders these as masked inputs ("••••") and round-trips them back on PUT;
+/// `apply_secret_passthrough` preserves the on-disk value whenever the
+/// sentinel arrives unchanged so non-secret edits don't accidentally wipe
+/// credentials.
+const REDACTED_SENTINEL: &str = "__redacted__";
+
+/// Build a copy of `config` safe to return over the API. Plaintext secrets
+/// (API tokens, GitHub PAT, NZBGet password, webhook signing secrets, the
+/// admin password hash) are replaced with [`REDACTED_SENTINEL`] when set,
+/// or left as `None`/empty when not configured.
+fn redact_config(mut config: amigo_core::config::Config) -> amigo_core::config::Config {
+    if config.server.api_token.is_some() {
+        config.server.api_token = Some(REDACTED_SENTINEL.into());
+    }
+    if config.server.admin_password_hash.is_some() {
+        config.server.admin_password_hash = Some(REDACTED_SENTINEL.into());
+    }
+    if !config.nzbget_api.password.is_empty() {
+        config.nzbget_api.password = REDACTED_SENTINEL.into();
+    }
+    if !config.feedback.github_token.is_empty() {
+        config.feedback.github_token = REDACTED_SENTINEL.into();
+    }
+    for hook in &mut config.webhooks {
+        if hook.secret.is_some() {
+            hook.secret = Some(REDACTED_SENTINEL.into());
+        }
+    }
+    config
+}
+
+/// When a PUT request comes back with a secret field still equal to
+/// [`REDACTED_SENTINEL`], that means the UI never saw the plaintext and is
+/// just round-tripping the masked value — keep the existing on-disk secret
+/// instead of overwriting it with the sentinel string.
+fn apply_secret_passthrough(
+    incoming: &mut amigo_core::config::Config,
+    existing: &amigo_core::config::Config,
+) {
+    if incoming.server.api_token.as_deref() == Some(REDACTED_SENTINEL) {
+        incoming.server.api_token = existing.server.api_token.clone();
+    }
+    if incoming.server.admin_password_hash.as_deref() == Some(REDACTED_SENTINEL) {
+        incoming.server.admin_password_hash = existing.server.admin_password_hash.clone();
+    }
+    if incoming.nzbget_api.password == REDACTED_SENTINEL {
+        incoming.nzbget_api.password = existing.nzbget_api.password.clone();
+    }
+    if incoming.feedback.github_token == REDACTED_SENTINEL {
+        incoming.feedback.github_token = existing.feedback.github_token.clone();
+    }
+    // Webhooks are matched by id; if a hook with the same id already exists
+    // and the incoming secret is the sentinel, restore the previous secret.
+    for hook in &mut incoming.webhooks {
+        if hook.secret.as_deref() == Some(REDACTED_SENTINEL) {
+            hook.secret = existing
+                .webhooks
+                .iter()
+                .find(|h| h.id == hook.id)
+                .and_then(|h| h.secret.clone());
+        }
+    }
+}
+
 async fn get_config(
     State(state): State<AppState>,
 ) -> Json<amigo_core::config::Config> {
-    Json(state.coordinator.config().await)
+    let config = state.coordinator.config().await;
+    Json(redact_config(config))
 }
 
 async fn put_config(
     State(state): State<AppState>,
-    Json(new_config): Json<amigo_core::config::Config>,
+    Json(mut new_config): Json<amigo_core::config::Config>,
 ) -> Result<Json<amigo_core::config::Config>, (StatusCode, Json<ErrorResponse>)> {
+    // Restore secrets the UI never saw so a "save settings" round-trip from
+    // a masked GET response cannot accidentally erase credentials.
+    let existing = state.coordinator.config().await;
+    apply_secret_passthrough(&mut new_config, &existing);
+
     // Save to TOML file
     new_config.save(&state.config_path).map_err(|e| {
         (
@@ -816,7 +887,7 @@ async fn put_config(
     state.coordinator.update_config(new_config.clone()).await;
 
     tracing::info!("Config updated and saved to {:?}", state.config_path);
-    Ok(Json(new_config))
+    Ok(Json(redact_config(new_config)))
 }
 
 // --- RSS feed handlers (feature-gated) ---
@@ -1061,5 +1132,109 @@ fn row_to_response(row: amigo_core::storage::DownloadRow) -> DownloadResponse {
         speed: row.speed_current,
         error: row.error_message,
         created_at: row.created_at,
+    }
+}
+
+#[cfg(test)]
+mod config_redact_tests {
+    use super::*;
+    use amigo_core::config::{Config, WebhookEndpoint};
+
+    fn config_with_secrets() -> Config {
+        let mut cfg = Config::default();
+        cfg.server.api_token = Some("ApiTokenAbc123".into());
+        cfg.server.admin_password_hash = Some("$argon2id$v=19$...".into());
+        cfg.nzbget_api.password = "nzbpass".into();
+        cfg.feedback.github_token = "ghp_realtoken".into();
+        cfg.webhooks.push(WebhookEndpoint {
+            id: "hook-1".into(),
+            name: "test".into(),
+            url: "https://example.com".into(),
+            secret: Some("hmacsecret".into()),
+            events: vec!["*".into()],
+            enabled: true,
+            retry_count: 3,
+            retry_delay_secs: 10,
+        });
+        cfg
+    }
+
+    #[test]
+    fn redact_replaces_every_secret_field() {
+        let redacted = redact_config(config_with_secrets());
+        assert_eq!(redacted.server.api_token.as_deref(), Some(REDACTED_SENTINEL));
+        assert_eq!(
+            redacted.server.admin_password_hash.as_deref(),
+            Some(REDACTED_SENTINEL)
+        );
+        assert_eq!(redacted.nzbget_api.password, REDACTED_SENTINEL);
+        assert_eq!(redacted.feedback.github_token, REDACTED_SENTINEL);
+        assert_eq!(
+            redacted.webhooks[0].secret.as_deref(),
+            Some(REDACTED_SENTINEL)
+        );
+    }
+
+    #[test]
+    fn redact_leaves_unset_fields_unset() {
+        let redacted = redact_config(Config::default());
+        assert!(redacted.server.api_token.is_none());
+        assert!(redacted.server.admin_password_hash.is_none());
+        assert_eq!(redacted.nzbget_api.password, "");
+        assert_eq!(redacted.feedback.github_token, "");
+        assert!(redacted.webhooks.is_empty());
+    }
+
+    #[test]
+    fn redacted_response_does_not_serialize_real_secrets() {
+        // Belt-and-braces: serialise the redacted config to JSON and grep
+        // for the plaintext secret values. They must not appear anywhere.
+        let cfg = config_with_secrets();
+        let redacted = redact_config(cfg);
+        let json = serde_json::to_string(&redacted).expect("serialise");
+        for needle in [
+            "ApiTokenAbc123",
+            "$argon2id$v=19$",
+            "nzbpass",
+            "ghp_realtoken",
+            "hmacsecret",
+        ] {
+            assert!(
+                !json.contains(needle),
+                "redacted config still contains plaintext '{needle}': {json}"
+            );
+        }
+    }
+
+    #[test]
+    fn passthrough_restores_sentinel_secrets_on_put() {
+        let existing = config_with_secrets();
+        let mut incoming = redact_config(existing.clone());
+        // The UI hands the masked sentinel back to us unchanged.
+        apply_secret_passthrough(&mut incoming, &existing);
+        assert_eq!(incoming.server.api_token, existing.server.api_token);
+        assert_eq!(
+            incoming.server.admin_password_hash,
+            existing.server.admin_password_hash
+        );
+        assert_eq!(incoming.nzbget_api.password, existing.nzbget_api.password);
+        assert_eq!(
+            incoming.feedback.github_token,
+            existing.feedback.github_token
+        );
+        assert_eq!(incoming.webhooks[0].secret, existing.webhooks[0].secret);
+    }
+
+    #[test]
+    fn passthrough_accepts_real_replacement_values() {
+        let existing = config_with_secrets();
+        let mut incoming = config_with_secrets();
+        incoming.feedback.github_token = "ghp_replaced".into();
+        incoming.nzbget_api.password = "newpass".into();
+        apply_secret_passthrough(&mut incoming, &existing);
+        // Non-sentinel secrets must come through unchanged so operators
+        // can actually rotate them.
+        assert_eq!(incoming.feedback.github_token, "ghp_replaced");
+        assert_eq!(incoming.nzbget_api.password, "newpass");
     }
 }

--- a/crates/server/src/api.rs
+++ b/crates/server/src/api.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use axum::{
     Json, Router,
-    extract::{Multipart, Path, State},
+    extract::{DefaultBodyLimit, Multipart, Path, State},
     http::StatusCode,
     routing::{delete, get, patch, post, put},
 };
@@ -38,8 +38,20 @@ pub fn router(state: AppState) -> Router {
         .route("/api/v1/downloads", get(list_downloads))
         // Specific download routes MUST come before {id} routes
         .route("/api/v1/downloads/batch", post(add_batch))
-        .route("/api/v1/downloads/nzb", post(upload_nzb))
-        .route("/api/v1/downloads/container", post(upload_container))
+        // NZB JSON bodies can be a few MiB for large releases; cap at 64 MiB
+        // so a malicious client can't exhaust memory by uploading a multi-GiB
+        // body. DLC containers are tiny (tens of KiB at most), so cap them
+        // at 1 MiB. Both overrides come from the audit's CRITICAL #3 finding
+        // — without them axum's default 2 MiB applied to one route and the
+        // multipart handler on the other could buffer arbitrary sizes.
+        .route(
+            "/api/v1/downloads/nzb",
+            post(upload_nzb).layer(DefaultBodyLimit::max(MAX_NZB_BODY_BYTES)),
+        )
+        .route(
+            "/api/v1/downloads/container",
+            post(upload_container).layer(DefaultBodyLimit::max(MAX_DLC_BODY_BYTES)),
+        )
         .route("/api/v1/downloads/usenet", get(list_usenet_downloads))
         .route("/api/v1/downloads/{id}", get(get_download))
         .route("/api/v1/downloads/{id}", patch(update_download))
@@ -791,6 +803,17 @@ async fn set_nzb_watch_dir(
         })?;
     Ok(Json(WatchDirResponse { path: req.path }))
 }
+
+// --- Body-size limits for upload endpoints (audit finding #3) ---
+
+/// Maximum size of an NZB JSON body. Real-world NZBs grow with article count;
+/// 64 MiB comfortably handles even multi-thousand-article releases while
+/// blocking obvious DoS payloads.
+const MAX_NZB_BODY_BYTES: usize = 64 * 1024 * 1024;
+
+/// Maximum size of a DLC container upload. DLC files carry an AES-CBC-
+/// encrypted XML link list; legitimate ones are kilobytes, never megabytes.
+const MAX_DLC_BODY_BYTES: usize = 1024 * 1024;
 
 // --- Unified config endpoint ---
 

--- a/crates/server/src/api.rs
+++ b/crates/server/src/api.rs
@@ -984,6 +984,21 @@ async fn add_rss_feed(
         ));
     }
 
+    // SSRF guard: refuse RSS feeds whose URL points at non-public targets
+    // (loopback, RFC1918, link-local, cloud metadata, …) or non-http(s)
+    // schemes. Without this, a privileged user could turn the feed poller
+    // into an internal scanner.
+    crate::net_guard::validate_outbound_url(&req.url, false)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: format!("RSS feed URL rejected: {e}"),
+                }),
+            )
+        })?;
+
     let id = uuid::Uuid::new_v4().to_string();
     let row = amigo_core::storage::RssFeedRow {
         id: id.clone(),
@@ -1098,6 +1113,20 @@ async fn create_webhook(
     State(state): State<AppState>,
     Json(req): Json<CreateWebhookRequest>,
 ) -> Result<(StatusCode, Json<serde_json::Value>), (StatusCode, Json<ErrorResponse>)> {
+    // SSRF guard: webhook URLs are operator-supplied. Without validation, a
+    // privileged user could register http://169.254.169.254/ (cloud metadata)
+    // or http://10.0.0.1/admin and have the server probe / exfiltrate.
+    crate::net_guard::validate_outbound_url(&req.url, false)
+        .await
+        .map_err(|e| {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: format!("Webhook URL rejected: {e}"),
+                }),
+            )
+        })?;
+
     let endpoint = amigo_core::config::WebhookEndpoint {
         id: uuid::Uuid::new_v4().to_string(),
         name: req.name,

--- a/crates/server/src/auth.rs
+++ b/crates/server/src/auth.rs
@@ -91,19 +91,21 @@ pub fn client_ip(
             return t.to_string();
         }
     }
-    if trust_proxy
-        && let Some(fwd) = headers.get("forwarded").and_then(|v| v.to_str().ok())
-    {
+    if trust_proxy && let Some(fwd) = headers.get("forwarded").and_then(|v| v.to_str().ok()) {
         for part in fwd.split(';').flat_map(|s| s.split(',')) {
             if let Some(v) = part.trim().strip_prefix("for=") {
-                let t = v.trim_matches('"').trim_start_matches('[').trim_end_matches(']');
+                let t = v
+                    .trim_matches('"')
+                    .trim_start_matches('[')
+                    .trim_end_matches(']');
                 if !t.is_empty() {
                     return t.to_string();
                 }
             }
         }
     }
-    peer.map(|s| s.ip().to_string()).unwrap_or_else(|| "unknown".into())
+    peer.map(|s| s.ip().to_string())
+        .unwrap_or_else(|| "unknown".into())
 }
 
 /// Whether the original request came in over HTTPS. When `trust_proxy` is
@@ -171,7 +173,10 @@ fn extract_session_cookie(headers: &HeaderMap) -> Option<&str> {
 #[allow(dead_code)]
 pub enum Principal {
     /// Browser session — carries the username.
-    Session { username: String, session_id: String },
+    Session {
+        username: String,
+        session_id: String,
+    },
     /// API-token holder (CLI / script).
     ApiToken { id: String, name: String },
     /// Legacy pre-shared token.
@@ -179,11 +184,7 @@ pub enum Principal {
 }
 
 /// Try every supported credential type. Returns `None` if nothing validates.
-pub async fn authenticate(
-    auth: &AuthState,
-    headers: &HeaderMap,
-    uri: &Uri,
-) -> Option<Principal> {
+pub async fn authenticate(auth: &AuthState, headers: &HeaderMap, uri: &Uri) -> Option<Principal> {
     let now = chrono::Utc::now().timestamp();
 
     // Session cookie.
@@ -191,12 +192,7 @@ pub async fn authenticate(
         && let Ok(Some(row)) = auth.app.coordinator.storage().get_session(sid).await
         && row.expires_at > now
     {
-        let _ = auth
-            .app
-            .coordinator
-            .storage()
-            .touch_session(sid, now)
-            .await;
+        let _ = auth.app.coordinator.storage().touch_session(sid, now).await;
         return Some(Principal::Session {
             username: row.username,
             session_id: row.id,
@@ -363,7 +359,10 @@ mod tests {
 
         // Legacy RFC 7239 Forwarded header.
         let mut h2 = HeaderMap::new();
-        h2.insert("forwarded", r#"for="198.51.100.7";proto=https"#.parse().unwrap());
+        h2.insert(
+            "forwarded",
+            r#"for="198.51.100.7";proto=https"#.parse().unwrap(),
+        );
         assert_eq!(client_ip(&h2, Some(peer), true), "198.51.100.7");
     }
 

--- a/crates/server/src/background.rs
+++ b/crates/server/src/background.rs
@@ -48,10 +48,7 @@ pub fn spawn_background_tasks(
 /// installed plugin. Controlled by `update.auto_update_plugins` in config
 /// (opt-in — defaults to off) with a lower bound of 1 hour between ticks
 /// to stop misconfigured short intervals from hammering the registry.
-fn spawn_plugin_auto_update(
-    coordinator: Arc<Coordinator>,
-    plugin_updater: Arc<PluginUpdater>,
-) {
+fn spawn_plugin_auto_update(coordinator: Arc<Coordinator>, plugin_updater: Arc<PluginUpdater>) {
     tokio::spawn(async move {
         // Sleep once before the first tick so we don't collide with startup
         // plugin discovery. Re-read config each iteration so the user can
@@ -305,10 +302,8 @@ fn extract_nzb_links(xml: &str) -> Vec<String> {
     let mut links = Vec::new();
 
     // Find enclosure URLs with .nzb
-    let enclosure_pattern = regex::Regex::new(
-        r#"<enclosure[^>]+url=["']([^"']+\.nzb[^"']*)["']"#,
-    )
-    .unwrap();
+    let enclosure_pattern =
+        regex::Regex::new(r#"<enclosure[^>]+url=["']([^"']+\.nzb[^"']*)["']"#).unwrap();
     for cap in enclosure_pattern.captures_iter(xml) {
         if let Some(url) = cap.get(1) {
             links.push(url.as_str().to_string());
@@ -316,8 +311,7 @@ fn extract_nzb_links(xml: &str) -> Vec<String> {
     }
 
     // Find <link> elements pointing to .nzb files
-    let link_pattern =
-        regex::Regex::new(r#"<link[^>]*>([^<]+\.nzb[^<]*)</link>"#).unwrap();
+    let link_pattern = regex::Regex::new(r#"<link[^>]*>([^<]+\.nzb[^<]*)</link>"#).unwrap();
     for cap in link_pattern.captures_iter(xml) {
         if let Some(url) = cap.get(1) {
             let url = url.as_str().trim();
@@ -328,8 +322,7 @@ fn extract_nzb_links(xml: &str) -> Vec<String> {
     }
 
     // Find href attributes pointing to .nzb
-    let href_pattern =
-        regex::Regex::new(r#"href=["']([^"']+\.nzb[^"']*)["']"#).unwrap();
+    let href_pattern = regex::Regex::new(r#"href=["']([^"']+\.nzb[^"']*)["']"#).unwrap();
     for cap in href_pattern.captures_iter(xml) {
         if let Some(url) = cap.get(1) {
             links.push(url.as_str().to_string());

--- a/crates/server/src/background.rs
+++ b/crates/server/src/background.rs
@@ -246,6 +246,13 @@ async fn fetch_and_process_feed(
     http_client: &reqwest::Client,
     feed: &amigo_core::storage::RssFeedRow,
 ) -> Result<u32, amigo_core::Error> {
+    // Re-validate the feed URL on every poll. Even though add_rss_feed
+    // checked it at insert time, a DNS A-record can later flip to a private
+    // IP — a textbook SSRF rebinding pattern.
+    crate::net_guard::validate_outbound_url(&feed.url, false)
+        .await
+        .map_err(|e| amigo_core::Error::Other(format!("RSS feed URL rejected: {e}")))?;
+
     let resp = http_client
         .get(&feed.url)
         .header("User-Agent", "amigo-downloader/0.1.0")

--- a/crates/server/src/clicknload.rs
+++ b/crates/server/src/clicknload.rs
@@ -40,8 +40,7 @@ pub async fn start_clicknload(coordinator: Arc<Coordinator>) -> anyhow::Result<(
         )
         .route(
             "/flash/addcrypted2",
-            post(flash_addcrypted2)
-                .layer(DefaultBodyLimit::max(MAX_FLASH_ADDCRYPTED_BYTES)),
+            post(flash_addcrypted2).layer(DefaultBodyLimit::max(MAX_FLASH_ADDCRYPTED_BYTES)),
         )
         .with_state(coordinator);
 

--- a/crates/server/src/clicknload.rs
+++ b/crates/server/src/clicknload.rs
@@ -3,27 +3,50 @@
 //! Implements the Click'n'Load v2 protocol used by browser extensions
 //! to send download links to the download manager.
 //! Compatible with JDownloader, pyLoad, and other tools.
+//!
+//! Security: the listener binds to `127.0.0.1` only; external clients can't
+//! reach it. Even so, every URL submitted via the protocol is run through
+//! [`crate::net_guard::validate_outbound_url`] before queueing, so a
+//! malicious local process / browser extension can't sneak in `file://`,
+//! `gopher://`, RFC1918, or cloud-metadata targets. Bodies are also capped
+//! (see `MAX_*_BYTES`) to stop DLC-bomb DoS.
 
 use std::sync::Arc;
 
 use axum::{
     Router,
-    extract::State,
+    extract::{DefaultBodyLimit, State},
     http::StatusCode,
     routing::{get, post},
 };
-use tracing::info;
+use tracing::{info, warn};
 
 use amigo_core::coordinator::Coordinator;
+
+/// Plain `flash/add` payload is one URL per line. 256 KiB is plenty for any
+/// realistic batch and refuses obvious DoS payloads.
+const MAX_FLASH_ADD_BYTES: usize = 256 * 1024;
+/// Encrypted DLC bodies wrap a base64-encoded link list; legitimate ones are
+/// kilobytes. 1 MiB matches the REST `/api/v1/downloads/container` limit.
+const MAX_FLASH_ADDCRYPTED_BYTES: usize = 1024 * 1024;
 
 /// Start the Click'n'Load listener on port 9666.
 pub async fn start_clicknload(coordinator: Arc<Coordinator>) -> anyhow::Result<()> {
     let app = Router::new()
         .route("/jdcheck.js", get(jdcheck))
-        .route("/flash/add", post(flash_add))
-        .route("/flash/addcrypted2", post(flash_addcrypted2))
+        .route(
+            "/flash/add",
+            post(flash_add).layer(DefaultBodyLimit::max(MAX_FLASH_ADD_BYTES)),
+        )
+        .route(
+            "/flash/addcrypted2",
+            post(flash_addcrypted2)
+                .layer(DefaultBodyLimit::max(MAX_FLASH_ADDCRYPTED_BYTES)),
+        )
         .with_state(coordinator);
 
+    // Bind explicitly to loopback. Anything else would expose the
+    // unauthenticated download-injection endpoint to the LAN.
     let bind = "127.0.0.1:9666";
     info!("Click'n'Load listener on {bind}");
 
@@ -51,8 +74,16 @@ async fn flash_add(
     info!("Click'n'Load: received {} links", urls.len());
 
     for url in urls {
+        // Even though the listener is loopback-only, a malicious browser
+        // extension or local process could submit file://, gopher://, or
+        // RFC1918 URLs and turn the queue into a probe. Filter through the
+        // server's outbound URL guard.
+        if let Err(e) = crate::net_guard::validate_outbound_url(url, false).await {
+            warn!("Click'n'Load: rejecting URL {url}: {e}");
+            continue;
+        }
         if let Err(e) = coord.add_download(url, None).await {
-            tracing::warn!("Click'n'Load: failed to add {url}: {e}");
+            warn!("Click'n'Load: failed to add {url}: {e}");
         }
     }
 
@@ -84,18 +115,29 @@ async fn flash_addcrypted2(
                 info!("Click'n'Load: DLC with {} links", link_count);
                 for pkg in &packages {
                     for link in &pkg.links {
+                        if let Err(e) =
+                            crate::net_guard::validate_outbound_url(&link.url, false).await
+                        {
+                            warn!("Click'n'Load: rejecting DLC URL {}: {e}", link.url);
+                            continue;
+                        }
                         let _ = coord.add_download(&link.url, link.filename.clone()).await;
                     }
                 }
             }
             Err(e) => {
-                tracing::warn!("Click'n'Load: failed to parse encrypted data: {e}");
+                warn!("Click'n'Load: failed to parse encrypted data: {e}");
                 // Fallback: treat as plain URL list
                 for line in decoded.lines() {
                     let url = line.trim();
-                    if !url.is_empty() {
-                        let _ = coord.add_download(url, None).await;
+                    if url.is_empty() {
+                        continue;
                     }
+                    if let Err(e) = crate::net_guard::validate_outbound_url(url, false).await {
+                        warn!("Click'n'Load: rejecting fallback URL {url}: {e}");
+                        continue;
+                    }
+                    let _ = coord.add_download(url, None).await;
                 }
             }
         }
@@ -125,4 +167,55 @@ fn urlencoding_decode(input: &str) -> String {
     }
 
     String::from_utf8(bytes).unwrap_or_else(|e| String::from_utf8_lossy(e.as_bytes()).into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::net_guard;
+
+    #[tokio::test]
+    async fn cnl_url_filter_rejects_dangerous_schemes() {
+        // The flash_add handler runs each line through validate_outbound_url
+        // before queueing. We exercise the same predicate directly so the
+        // test does not need a full Coordinator + reqwest harness.
+        for url in [
+            "file:///etc/passwd",
+            "gopher://attacker.example/x",
+            "ftp://intranet/secret",
+        ] {
+            let err = net_guard::validate_outbound_url(url, false)
+                .await
+                .expect_err(&format!("scheme must be blocked: {url}"));
+            assert!(
+                matches!(err, net_guard::GuardError::BadScheme(_)),
+                "{url} → {err}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn cnl_url_filter_rejects_private_ips() {
+        for url in [
+            "http://127.0.0.1:22/",
+            "http://10.0.0.1/",
+            "http://169.254.169.254/latest/",
+        ] {
+            let err = net_guard::validate_outbound_url(url, false)
+                .await
+                .expect_err(&format!("private IP must be blocked: {url}"));
+            assert!(
+                matches!(err, net_guard::GuardError::BlockedAddress { .. }),
+                "{url} → {err}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn cnl_url_filter_accepts_public_https() {
+        // example.com / www.example.com is reserved for documentation but
+        // resolves to public IPs, so the guard should let it through.
+        net_guard::validate_outbound_url("https://www.example.com/file.zip", false)
+            .await
+            .expect("public HTTPS must be accepted");
+    }
 }

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -7,6 +7,7 @@ mod background;
 pub mod clicknload;
 mod feedback;
 pub mod login;
+pub mod net_guard;
 mod nzbget_api;
 pub mod pairing;
 pub mod password;

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -9,6 +9,8 @@ mod feedback;
 pub mod login;
 pub mod net_guard;
 mod nzbget_api;
+mod security_headers;
+pub use security_headers::security_headers as security_headers_layer;
 pub mod pairing;
 pub mod password;
 mod resolver;

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -62,10 +62,8 @@ pub fn build_test_state(config: Config) -> api::AppState {
 
     let webhook_dispatcher = Arc::new(webhooks::WebhookDispatcher::new(Vec::new()));
 
-    let config_path = std::env::temp_dir().join(format!(
-        "amigo-test-config-{}.toml",
-        uuid::Uuid::new_v4()
-    ));
+    let config_path =
+        std::env::temp_dir().join(format!("amigo-test-config-{}.toml", uuid::Uuid::new_v4()));
 
     api::AppState {
         coordinator,
@@ -80,8 +78,7 @@ pub fn build_test_state(config: Config) -> api::AppState {
 
 /// Build the full Axum router for testing (API + WS, no static files).
 pub fn build_test_router(state: api::AppState) -> axum::Router {
-    api::router(state.clone())
-        .merge(ws::ws_router(state.clone()))
+    api::router(state.clone()).merge(ws::ws_router(state.clone()))
 }
 
 /// Build the full router including setup / login / pairing routes and the

--- a/crates/server/src/login.rs
+++ b/crates/server/src/login.rs
@@ -126,11 +126,7 @@ async fn logout(
 ) -> Response {
     let (app, _) = &*s;
     if let Some(Principal::Session { session_id, .. }) = req.extensions().get::<Principal>() {
-        let _ = app
-            .coordinator
-            .storage()
-            .delete_session(session_id)
-            .await;
+        let _ = app.coordinator.storage().delete_session(session_id).await;
     }
     // Clear the cookie regardless; the client may be a stale bearer user.
     let clear = Cookie::build((SESSION_COOKIE, ""))

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -6,6 +6,7 @@ mod feedback;
 mod login;
 mod net_guard;
 mod nzbget_api;
+mod security_headers;
 mod pairing;
 mod password;
 mod resolver;
@@ -295,7 +296,12 @@ async fn main() -> anyhow::Result<()> {
     let app = app
         .merge(static_files::static_router())
         .layer(setup_guard_layer)
-        .layer(cors);
+        .layer(cors)
+        // Set baseline security headers (X-Content-Type-Options, X-Frame-
+        // Options, Referrer-Policy, CSP, Permissions-Policy) on every
+        // response. Outermost layer so even error / redirect responses
+        // carry them.
+        .layer(axum::middleware::from_fn(security_headers::security_headers));
 
     // Start background tasks (NZB watch folder, RSS poller)
     background::spawn_background_tasks(

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -6,10 +6,10 @@ mod feedback;
 mod login;
 mod net_guard;
 mod nzbget_api;
-mod security_headers;
 mod pairing;
 mod password;
 mod resolver;
+mod security_headers;
 mod setup;
 mod static_files;
 mod update_api;
@@ -88,8 +88,8 @@ async fn main() -> anyhow::Result<()> {
             );
             anyhow::bail!("invalid setup env vars");
         }
-        let hash = password::hash_password(&pw)
-            .map_err(|e| anyhow::anyhow!("setup hash failed: {e}"))?;
+        let hash =
+            password::hash_password(&pw).map_err(|e| anyhow::anyhow!("setup hash failed: {e}"))?;
         config.server.admin_username = Some(user);
         config.server.admin_password_hash = Some(hash);
         config.server.setup_complete = true;
@@ -138,23 +138,21 @@ async fn main() -> anyhow::Result<()> {
     // Wire captcha callback: plugin → CaptchaManager → WebSocket → UI → REST → plugin
     {
         let cm = captcha_manager.clone();
-        plugin_host_api.set_captcha_callback(Arc::new(move |plugin_id, download_id, image_url, captcha_type| {
-            let cm = cm.clone();
-            Box::pin(async move {
-                cm.request_solve(&plugin_id, &download_id, &image_url, &captcha_type)
-                    .await
-                    .map_err(|e| e.to_string())
-            })
-        }));
+        plugin_host_api.set_captcha_callback(Arc::new(
+            move |plugin_id, download_id, image_url, captcha_type| {
+                let cm = cm.clone();
+                Box::pin(async move {
+                    cm.request_solve(&plugin_id, &download_id, &image_url, &captcha_type)
+                        .await
+                        .map_err(|e| e.to_string())
+                })
+            },
+        ));
     }
 
     let plugin_loader = Arc::new(
-        PluginLoader::new_with_host_api(
-            PathBuf::from("plugins"),
-            sandbox_limits,
-            plugin_host_api,
-        )
-        .expect("Failed to initialize plugin runtime — cannot start server"),
+        PluginLoader::new_with_host_api(PathBuf::from("plugins"), sandbox_limits, plugin_host_api)
+            .expect("Failed to initialize plugin runtime — cannot start server"),
     );
     let discovered = plugin_loader.discover().await.unwrap_or_default();
     tracing::info!("Loaded {} plugins", discovered.len());
@@ -263,14 +261,9 @@ async fn main() -> anyhow::Result<()> {
             bind = config.server.bind
         );
     }
-    let auth_layer = axum::middleware::from_fn_with_state(
-        auth_state.clone(),
-        auth::require_auth,
-    );
-    let setup_guard_layer = axum::middleware::from_fn_with_state(
-        auth_state.clone(),
-        auth::setup_guard,
-    );
+    let auth_layer = axum::middleware::from_fn_with_state(auth_state.clone(), auth::require_auth);
+    let setup_guard_layer =
+        axum::middleware::from_fn_with_state(auth_state.clone(), auth::setup_guard);
 
     let protected = api::router(state.clone())
         .merge(ws::ws_router(state.clone()))
@@ -301,7 +294,9 @@ async fn main() -> anyhow::Result<()> {
         // Options, Referrer-Policy, CSP, Permissions-Policy) on every
         // response. Outermost layer so even error / redirect responses
         // carry them.
-        .layer(axum::middleware::from_fn(security_headers::security_headers));
+        .layer(axum::middleware::from_fn(
+            security_headers::security_headers,
+        ));
 
     // Start background tasks (NZB watch folder, RSS poller)
     background::spawn_background_tasks(

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -283,10 +283,15 @@ async fn main() -> anyhow::Result<()> {
         .merge(pairing::pairing_router(state.clone(), auth_state.clone()));
 
     // NZBGet JSON-RPC has its own HTTP Basic Auth layer (Sonarr/Radarr
-    // compatibility) and static files are public.
-    let app = protected
-        .merge(open)
-        .merge(nzbget_api::nzbget_router(state.clone()))
+    // compatibility) and static files are public. Refuse to start when the
+    // operator turned the API on without setting credentials — fail-loud at
+    // startup is safer than mounting an open RPC endpoint.
+    nzbget_api::validate_nzbget_config(&config.nzbget_api).map_err(|e| anyhow::anyhow!(e))?;
+    let mut app = protected.merge(open);
+    if let Some(nzb) = nzbget_api::nzbget_router(state.clone(), &config.nzbget_api) {
+        app = app.merge(nzb);
+    }
+    let app = app
         .merge(static_files::static_router())
         .layer(setup_guard_layer)
         .layer(cors);

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -4,6 +4,7 @@ mod background;
 mod clicknload;
 mod feedback;
 mod login;
+mod net_guard;
 mod nzbget_api;
 mod pairing;
 mod password;

--- a/crates/server/src/net_guard.rs
+++ b/crates/server/src/net_guard.rs
@@ -1,0 +1,222 @@
+//! Outbound-URL guard for server-initiated HTTP requests.
+//!
+//! Server features (webhook dispatch, RSS feed polling, plugin marketplace,
+//! self-update, feedback) issue HTTP requests to operator-supplied URLs.
+//! Without a guard those URLs can target loopback / RFC1918 / link-local /
+//! cloud-metadata addresses, turning the server into an SSRF gadget that
+//! probes internal services or exfiltrates data.
+//!
+//! [`validate_outbound_url`] resolves the URL's host (including IP literals)
+//! and rejects schemes other than `http`/`https`, malformed URLs, and any
+//! resolved address inside a non-public block. Call it at request time, not
+//! once at config save: DNS-rebinding attacks rely on changing the answer
+//! between validation and the actual fetch.
+//!
+//! Mirrors the plugin-runtime `host_api::is_blocked_ip` policy so plugins,
+//! webhooks, and RSS feeds all see the same allowlist.
+
+use std::net::IpAddr;
+
+use thiserror::Error;
+use url::Url;
+
+#[derive(Debug, Error)]
+pub enum GuardError {
+    #[error("URL is malformed: {0}")]
+    Malformed(String),
+    #[error("URL scheme '{0}' is not allowed (must be http or https)")]
+    BadScheme(String),
+    #[error("URL has no host component")]
+    MissingHost,
+    #[error("DNS resolution failed for {host}: {source}")]
+    DnsFailed {
+        host: String,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("URL resolves to a non-public address ({addr}) — refusing to issue request")]
+    BlockedAddress { addr: IpAddr },
+}
+
+/// Validate that `url` is safe to fetch from the server.
+///
+/// `allow_private_targets = true` skips the IP-block list, intended for
+/// operators who explicitly need to reach LAN hosts (e.g. a self-hosted
+/// webhook receiver). Scheme validation still runs.
+pub async fn validate_outbound_url(
+    url: &str,
+    allow_private_targets: bool,
+) -> Result<(), GuardError> {
+    let parsed = Url::parse(url).map_err(|e| GuardError::Malformed(e.to_string()))?;
+    match parsed.scheme() {
+        "http" | "https" => {}
+        other => return Err(GuardError::BadScheme(other.to_string())),
+    }
+    let host = parsed.host().ok_or(GuardError::MissingHost)?;
+    if allow_private_targets {
+        return Ok(());
+    }
+    let port = parsed.port_or_known_default().unwrap_or(80);
+
+    // url::Host distinguishes IP literals from DNS names so we can check IP
+    // forms directly without having to strip the IPv6 brackets that
+    // host_str() returns.
+    let dns_target = match host {
+        url::Host::Ipv4(ip) => {
+            let ip = IpAddr::V4(ip);
+            if is_blocked_ip(ip) {
+                return Err(GuardError::BlockedAddress { addr: ip });
+            }
+            return Ok(());
+        }
+        url::Host::Ipv6(ip) => {
+            let ip = IpAddr::V6(ip);
+            if is_blocked_ip(ip) {
+                return Err(GuardError::BlockedAddress { addr: ip });
+            }
+            return Ok(());
+        }
+        url::Host::Domain(d) => d.to_string(),
+    };
+
+    let addrs = tokio::net::lookup_host((dns_target.as_str(), port))
+        .await
+        .map_err(|e| GuardError::DnsFailed {
+            host: dns_target.clone(),
+            source: e,
+        })?;
+    for addr in addrs {
+        if is_blocked_ip(addr.ip()) {
+            return Err(GuardError::BlockedAddress { addr: addr.ip() });
+        }
+    }
+    Ok(())
+}
+
+/// Return `true` for any address that is not safely reachable as a public
+/// destination: loopback, RFC1918, CGNAT, link-local, broadcast, the AWS/GCP
+/// metadata IP (169.254.169.254), unique-local IPv6, and IPv6-mapped versions
+/// of any of the above.
+fn is_blocked_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            if v4.is_loopback()
+                || v4.is_private()
+                || v4.is_link_local()
+                || v4.is_broadcast()
+                || v4.is_unspecified()
+                || v4.is_documentation()
+            {
+                return true;
+            }
+            let o = v4.octets();
+            // CGNAT 100.64.0.0/10 — used by ISPs for shared IPv4, not safe
+            // as an arbitrary target.
+            o[0] == 100 && (64..=127).contains(&o[1])
+        }
+        IpAddr::V6(v6) => {
+            if v6.is_loopback() || v6.is_unspecified() {
+                return true;
+            }
+            let segs = v6.segments();
+            // Unique-local fc00::/7
+            if (segs[0] & 0xfe00) == 0xfc00 {
+                return true;
+            }
+            // Link-local fe80::/10
+            if (segs[0] & 0xffc0) == 0xfe80 {
+                return true;
+            }
+            if let Some(v4) = v6.to_ipv4_mapped() {
+                return is_blocked_ip(IpAddr::V4(v4));
+            }
+            false
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn rejects_loopback_literal() {
+        let err = validate_outbound_url("http://127.0.0.1/foo", false)
+            .await
+            .expect_err("loopback must be blocked");
+        assert!(matches!(err, GuardError::BlockedAddress { .. }), "{err}");
+    }
+
+    #[tokio::test]
+    async fn rejects_aws_metadata_ip() {
+        let err = validate_outbound_url("http://169.254.169.254/latest/meta-data/", false)
+            .await
+            .expect_err("AWS metadata IP must be blocked");
+        assert!(matches!(err, GuardError::BlockedAddress { .. }), "{err}");
+    }
+
+    #[tokio::test]
+    async fn rejects_rfc1918_literal() {
+        for host in ["10.0.0.1", "192.168.0.1", "172.16.0.1"] {
+            let url = format!("https://{host}/x");
+            let err = validate_outbound_url(&url, false)
+                .await
+                .expect_err("RFC1918 must be blocked");
+            assert!(matches!(err, GuardError::BlockedAddress { .. }), "{err}");
+        }
+    }
+
+    #[tokio::test]
+    async fn rejects_ipv6_loopback_and_ula() {
+        for url in ["http://[::1]/x", "http://[fc00::1]/x", "http://[fe80::1]/x"] {
+            let err = validate_outbound_url(url, false)
+                .await
+                .expect_err("non-public v6 must be blocked");
+            assert!(matches!(err, GuardError::BlockedAddress { .. }), "{url} → {err}");
+        }
+    }
+
+    #[tokio::test]
+    async fn rejects_unsupported_scheme() {
+        for url in [
+            "file:///etc/passwd",
+            "gopher://attacker.example/x",
+            "ftp://intranet/secret",
+            "data:text/plain,hi",
+        ] {
+            let err = validate_outbound_url(url, false)
+                .await
+                .expect_err("scheme must be blocked");
+            assert!(matches!(err, GuardError::BadScheme(_)), "{url} → {err}");
+        }
+    }
+
+    #[tokio::test]
+    async fn allow_private_skips_ip_check_but_still_checks_scheme() {
+        // Loopback is allowed when caller opts into private targets.
+        validate_outbound_url("http://127.0.0.1/x", true)
+            .await
+            .expect("loopback should be allowed when opted in");
+        // But unsupported schemes are still rejected.
+        let err = validate_outbound_url("file:///etc/passwd", true)
+            .await
+            .expect_err("scheme check still applies");
+        assert!(matches!(err, GuardError::BadScheme(_)), "{err}");
+    }
+
+    #[tokio::test]
+    async fn rejects_malformed_url() {
+        let err = validate_outbound_url("not a url at all", false)
+            .await
+            .expect_err("must reject malformed");
+        assert!(matches!(err, GuardError::Malformed(_)), "{err}");
+    }
+
+    #[test]
+    fn ipv4_mapped_v6_inherits_v4_block() {
+        let ip: IpAddr = "::ffff:127.0.0.1".parse().unwrap();
+        assert!(is_blocked_ip(ip));
+        let ip: IpAddr = "::ffff:169.254.169.254".parse().unwrap();
+        assert!(is_blocked_ip(ip));
+    }
+}

--- a/crates/server/src/net_guard.rs
+++ b/crates/server/src/net_guard.rs
@@ -172,7 +172,10 @@ mod tests {
             let err = validate_outbound_url(url, false)
                 .await
                 .expect_err("non-public v6 must be blocked");
-            assert!(matches!(err, GuardError::BlockedAddress { .. }), "{url} → {err}");
+            assert!(
+                matches!(err, GuardError::BlockedAddress { .. }),
+                "{url} → {err}"
+            );
         }
     }
 

--- a/crates/server/src/nzbget_api.rs
+++ b/crates/server/src/nzbget_api.rs
@@ -33,7 +33,10 @@ static SERVER_START: std::sync::LazyLock<Instant> = std::sync::LazyLock::new(Ins
 /// caller (main.rs) refuses to start in the latter case via
 /// [`validate_nzbget_config`], so a `None` here always means "intentionally
 /// off".
-pub fn nzbget_router(state: AppState, config: &amigo_core::config::NzbGetApiConfig) -> Option<Router> {
+pub fn nzbget_router(
+    state: AppState,
+    config: &amigo_core::config::NzbGetApiConfig,
+) -> Option<Router> {
     if !config.enabled {
         debug!("NZBGet JSON-RPC API disabled");
         return None;
@@ -153,7 +156,11 @@ async fn jsonrpc_handler(
     Json(req): Json<JsonRpcRequest>,
 ) -> impl IntoResponse {
     let config = state.coordinator.config().await;
-    if !check_basic_auth(&headers, &config.nzbget_api.username, &config.nzbget_api.password) {
+    if !check_basic_auth(
+        &headers,
+        &config.nzbget_api.username,
+        &config.nzbget_api.password,
+    ) {
         return (
             StatusCode::UNAUTHORIZED,
             Json(json!({"id": null, "error": {"code": -32000, "message": "Unauthorized"}})),
@@ -198,10 +205,7 @@ async fn jsonrpc_handler(
     };
 
     match result {
-        Ok(value) => (
-            StatusCode::OK,
-            Json(json!({"id": id, "result": value})),
-        ),
+        Ok(value) => (StatusCode::OK, Json(json!({"id": id, "result": value}))),
         Err((code, msg)) => (
             StatusCode::OK, // JSON-RPC errors still return 200
             Json(json!({"id": id, "error": {"code": code, "message": msg}})),
@@ -270,7 +274,10 @@ async fn handle_status(coordinator: &Arc<Coordinator>) -> RpcResult {
 
 async fn handle_append(coordinator: &Arc<Coordinator>, params: &[Value]) -> RpcResult {
     // append(NZBFilename, NZBContent, Category, Priority, AddToTop, AddPaused, DupeKey, DupeScore, DupeMode, PPParameters)
-    let nzb_filename = params.first().and_then(|v| v.as_str()).unwrap_or("upload.nzb");
+    let nzb_filename = params
+        .first()
+        .and_then(|v| v.as_str())
+        .unwrap_or("upload.nzb");
     let nzb_content = params.get(1).and_then(|v| v.as_str()).unwrap_or("");
     let _category = params.get(2).and_then(|v| v.as_str()).unwrap_or("");
     let _priority = params.get(3).and_then(|v| v.as_i64()).unwrap_or(0);
@@ -302,8 +309,8 @@ async fn handle_append(coordinator: &Arc<Coordinator>, params: &[Value]) -> RpcR
             .map_err(|e| (-32602, format!("Invalid base64 NZB content: {e}")))?
     };
 
-    let nzb_str = String::from_utf8(nzb_data)
-        .map_err(|e| (-32602, format!("Invalid UTF-8 in NZB: {e}")))?;
+    let nzb_str =
+        String::from_utf8(nzb_data).map_err(|e| (-32602, format!("Invalid UTF-8 in NZB: {e}")))?;
 
     // Validate NZB
     amigo_core::protocol::usenet::nzb::parse_nzb(&nzb_str)
@@ -485,7 +492,11 @@ async fn handle_editqueue(coordinator: &Arc<Coordinator>, params: &[Value]) -> R
         }
 
         // Find download by nzbid
-        let all = coordinator.storage().list_downloads().await.unwrap_or_default();
+        let all = coordinator
+            .storage()
+            .list_downloads()
+            .await
+            .unwrap_or_default();
         let download = all.iter().find(|d| id_to_nzbid(&d.id) == nzbid as i32);
 
         if let Some(dl) = download {
@@ -578,10 +589,7 @@ mod tests {
         let mut h = HeaderMap::new();
         let creds = format!("{user}:{pass}");
         let encoded = base64::engine::general_purpose::STANDARD.encode(creds);
-        h.insert(
-            "authorization",
-            format!("Basic {encoded}").parse().unwrap(),
-        );
+        h.insert("authorization", format!("Basic {encoded}").parse().unwrap());
         h
     }
 
@@ -660,10 +668,7 @@ mod tests {
         // Header is valid base64 but does not contain a colon.
         let mut no_colon = HeaderMap::new();
         let encoded = base64::engine::general_purpose::STANDARD.encode("nocolonhere");
-        no_colon.insert(
-            "authorization",
-            format!("Basic {encoded}").parse().unwrap(),
-        );
+        no_colon.insert("authorization", format!("Basic {encoded}").parse().unwrap());
         assert!(!check_basic_auth(&no_colon, "alice", "secret"));
     }
 

--- a/crates/server/src/nzbget_api.rs
+++ b/crates/server/src/nzbget_api.rs
@@ -27,14 +27,52 @@ use crate::api::AppState;
 static SERVER_START: std::sync::LazyLock<Instant> = std::sync::LazyLock::new(Instant::now);
 
 /// NZBGet-compatible JSON-RPC router.
-pub fn nzbget_router(state: AppState) -> Router {
+///
+/// Returns `None` when the NZBGet compatibility layer is disabled in config
+/// (the default), or when it is enabled but credentials are missing — the
+/// caller (main.rs) refuses to start in the latter case via
+/// [`validate_nzbget_config`], so a `None` here always means "intentionally
+/// off".
+pub fn nzbget_router(state: AppState, config: &amigo_core::config::NzbGetApiConfig) -> Option<Router> {
+    if !config.enabled {
+        debug!("NZBGet JSON-RPC API disabled");
+        return None;
+    }
+    if config.username.is_empty() || config.password.is_empty() {
+        // Defense-in-depth: validate_nzbget_config should have caught this
+        // already, but if a config reload races with router construction we
+        // refuse to mount an open endpoint.
+        warn!("NZBGet JSON-RPC API enabled but credentials missing — not mounting");
+        return None;
+    }
     // Initialize the start time
     let _ = *SERVER_START;
 
-    Router::new()
-        .route("/jsonrpc", post(jsonrpc_handler))
-        .route("/{_username}/jsonrpc", post(jsonrpc_handler))
-        .with_state(state)
+    info!("NZBGet JSON-RPC API enabled at /jsonrpc");
+    Some(
+        Router::new()
+            .route("/jsonrpc", post(jsonrpc_handler))
+            .route("/{_username}/jsonrpc", post(jsonrpc_handler))
+            .with_state(state),
+    )
+}
+
+/// Validate the NZBGet configuration at startup. Returns an error suitable
+/// for surfacing to the operator when the API is enabled without credentials,
+/// which would otherwise be a wide-open RPC endpoint.
+pub fn validate_nzbget_config(config: &amigo_core::config::NzbGetApiConfig) -> Result<(), String> {
+    if !config.enabled {
+        return Ok(());
+    }
+    if config.username.is_empty() || config.password.is_empty() {
+        return Err(
+            "nzbget_api.enabled = true but username/password are empty — refusing to expose \
+             an unauthenticated NZBGet JSON-RPC endpoint. Set both credentials or set \
+             nzbget_api.enabled = false."
+                .to_string(),
+        );
+    }
+    Ok(())
 }
 
 // --- JSON-RPC types ---
@@ -71,9 +109,12 @@ struct JsonRpcErrorDetail {
 // --- Auth ---
 
 fn check_basic_auth(headers: &HeaderMap, expected_user: &str, expected_pass: &str) -> bool {
-    // If both username and password are empty, auth is disabled
-    if expected_user.is_empty() && expected_pass.is_empty() {
-        return true;
+    // The router only mounts when credentials are non-empty (see
+    // `nzbget_router` + `validate_nzbget_config`). If they ever land here
+    // empty due to a runtime config edit, fail closed instead of returning
+    // true.
+    if expected_user.is_empty() || expected_pass.is_empty() {
+        return false;
     }
 
     let Some(auth) = headers.get("authorization") else {
@@ -96,7 +137,12 @@ fn check_basic_auth(headers: &HeaderMap, expected_user: &str, expected_pass: &st
         return false;
     };
 
-    user == expected_user && pass == expected_pass
+    // Constant-time comparison to avoid timing-side-channel leaks of the
+    // configured credentials.
+    use subtle::ConstantTimeEq;
+    let user_eq = user.as_bytes().ct_eq(expected_user.as_bytes());
+    let pass_eq = pass.as_bytes().ct_eq(expected_pass.as_bytes());
+    bool::from(user_eq & pass_eq)
 }
 
 // --- Handler ---
@@ -520,4 +566,120 @@ fn id_to_nzbid(id: &str) -> i32 {
     id.hash(&mut hasher);
     // Ensure positive, non-zero
     (hasher.finish() as i32).abs().max(1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use amigo_core::config::NzbGetApiConfig;
+    use base64::Engine;
+
+    fn header_map_with_auth(user: &str, pass: &str) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        let creds = format!("{user}:{pass}");
+        let encoded = base64::engine::general_purpose::STANDARD.encode(creds);
+        h.insert(
+            "authorization",
+            format!("Basic {encoded}").parse().unwrap(),
+        );
+        h
+    }
+
+    #[test]
+    fn validate_rejects_enabled_without_credentials() {
+        let cfg = NzbGetApiConfig {
+            enabled: true,
+            username: String::new(),
+            password: String::new(),
+        };
+        let err = validate_nzbget_config(&cfg).expect_err("must reject");
+        assert!(err.contains("nzbget_api"));
+
+        let cfg = NzbGetApiConfig {
+            enabled: true,
+            username: "alice".into(),
+            password: String::new(),
+        };
+        validate_nzbget_config(&cfg).expect_err("password required");
+
+        let cfg = NzbGetApiConfig {
+            enabled: true,
+            username: String::new(),
+            password: "secret".into(),
+        };
+        validate_nzbget_config(&cfg).expect_err("username required");
+    }
+
+    #[test]
+    fn validate_accepts_disabled_or_fully_configured() {
+        validate_nzbget_config(&NzbGetApiConfig {
+            enabled: false,
+            username: String::new(),
+            password: String::new(),
+        })
+        .expect("disabled is fine");
+        validate_nzbget_config(&NzbGetApiConfig {
+            enabled: true,
+            username: "alice".into(),
+            password: "secret".into(),
+        })
+        .expect("fully configured is fine");
+    }
+
+    #[test]
+    fn check_basic_auth_rejects_empty_expected_credentials() {
+        // Defense in depth: even if expected creds somehow land here empty,
+        // never treat that as "auth disabled = pass". Previous behaviour
+        // returned true on (empty, empty), which let any LAN client drive
+        // the JSON-RPC API once the router was mounted.
+        let h = header_map_with_auth("alice", "secret");
+        assert!(!check_basic_auth(&h, "", ""));
+        assert!(!check_basic_auth(&h, "alice", ""));
+        assert!(!check_basic_auth(&h, "", "secret"));
+    }
+
+    #[test]
+    fn check_basic_auth_accepts_correct_creds() {
+        let h = header_map_with_auth("alice", "s3cret");
+        assert!(check_basic_auth(&h, "alice", "s3cret"));
+    }
+
+    #[test]
+    fn check_basic_auth_rejects_mismatch_or_malformed() {
+        let h = header_map_with_auth("alice", "wrong");
+        assert!(!check_basic_auth(&h, "alice", "right"));
+
+        let mut bad = HeaderMap::new();
+        bad.insert("authorization", "Bearer xyz".parse().unwrap());
+        assert!(!check_basic_auth(&bad, "alice", "secret"));
+
+        let mut malformed = HeaderMap::new();
+        malformed.insert("authorization", "Basic !!!not-base64".parse().unwrap());
+        assert!(!check_basic_auth(&malformed, "alice", "secret"));
+
+        // Header is valid base64 but does not contain a colon.
+        let mut no_colon = HeaderMap::new();
+        let encoded = base64::engine::general_purpose::STANDARD.encode("nocolonhere");
+        no_colon.insert(
+            "authorization",
+            format!("Basic {encoded}").parse().unwrap(),
+        );
+        assert!(!check_basic_auth(&no_colon, "alice", "secret"));
+    }
+
+    #[test]
+    fn router_returns_none_when_disabled() {
+        // We can't construct a full AppState here without bringing in
+        // half the server crate, so we exercise the configuration gate at
+        // the validate_* layer plus the empty-creds branch via a lightweight
+        // smoke test.
+        let cfg = NzbGetApiConfig {
+            enabled: false,
+            username: "alice".into(),
+            password: "secret".into(),
+        };
+        // disabled → no router. We can't build AppState easily here;
+        // confirm via the config gate that nzbget_router would early-exit.
+        assert!(!cfg.enabled);
+    }
 }

--- a/crates/server/src/pairing.rs
+++ b/crates/server/src/pairing.rs
@@ -77,8 +77,7 @@ pub fn pairing_router(state: AppState, auth: AuthState) -> Router {
         auth: auth.clone(),
         rl: Arc::new(Mutex::new(HashMap::new())),
     };
-    let auth_layer =
-        axum::middleware::from_fn_with_state(auth.clone(), crate::auth::require_auth);
+    let auth_layer = axum::middleware::from_fn_with_state(auth.clone(), crate::auth::require_auth);
 
     Router::new()
         .route(
@@ -89,10 +88,7 @@ pub fn pairing_router(state: AppState, auth: AuthState) -> Router {
             "/api/v1/pairing/approve",
             post(approve).route_layer(auth_layer.clone()),
         )
-        .route(
-            "/api/v1/pairing/deny",
-            post(deny).route_layer(auth_layer),
-        )
+        .route("/api/v1/pairing/deny", post(deny).route_layer(auth_layer))
         .route("/api/v1/pairing/start", post(start))
         .route("/api/v1/pairing/status", get(status))
         .with_state(ps)
@@ -227,10 +223,7 @@ async fn start(
     .into_response()
 }
 
-async fn status(
-    State(ps): State<PairingState>,
-    Query(q): Query<StatusQuery>,
-) -> Response {
+async fn status(State(ps): State<PairingState>, Query(q): Query<StatusQuery>) -> Response {
     let hash = auth::hash_api_token(&q.poll_token);
 
     // Housekeeping: flip stale pending rows to 'expired' before we look.
@@ -303,10 +296,7 @@ async fn list_pending(State(ps): State<PairingState>) -> Response {
     }
 }
 
-async fn approve(
-    State(ps): State<PairingState>,
-    Json(req): Json<IdRequest>,
-) -> Response {
+async fn approve(State(ps): State<PairingState>, Json(req): Json<IdRequest>) -> Response {
     // Generate a fresh bearer token; store hashed on api_tokens, plain on
     // the pairing row (consumed exactly once by `/status`).
     let plain = rand_hex(32);

--- a/crates/server/src/resolver.rs
+++ b/crates/server/src/resolver.rs
@@ -27,10 +27,7 @@ impl UrlResolver for PluginUrlResolver {
         let package = match self.loader.resolve(&plugin_meta.id, url).await {
             Ok(pkg) => pkg,
             Err(e) => {
-                tracing::warn!(
-                    "Plugin '{}' failed to resolve {url}: {e}",
-                    plugin_meta.name
-                );
+                tracing::warn!("Plugin '{}' failed to resolve {url}: {e}", plugin_meta.name);
                 return None;
             }
         };

--- a/crates/server/src/security_headers.rs
+++ b/crates/server/src/security_headers.rs
@@ -1,0 +1,94 @@
+//! Security-headers middleware.
+//!
+//! Wraps the Axum response stack so every response carries the standard
+//! defence-in-depth headers (clickjacking protection, MIME sniffing, referrer
+//! policy, baseline CSP). Without these, a stored XSS in plugin metadata or
+//! a misconfigured CDN can be exploited far more easily.
+//!
+//! The Strict-Transport-Security header is *not* set unconditionally — it
+//! would break local HTTP setups. Operators behind a TLS-terminating proxy
+//! can opt in by trusting `X-Forwarded-Proto: https` (see `config.server.trust_proxy`).
+
+use axum::{
+    extract::Request,
+    http::{HeaderName, HeaderValue, header},
+    middleware::Next,
+    response::Response,
+};
+
+/// `Content-Security-Policy` for the bundled web UI.
+///
+/// `connect-src` allows same-origin XHR, the in-process WebSocket, and any
+/// HTTP/HTTPS URL the UI may need (the API surfaces external thumbnails,
+/// captcha images, etc.). `style-src 'unsafe-inline'` is unfortunately
+/// required by Svelte's scoped styles; the rest of the policy keeps script
+/// execution to first-party resources only.
+const DEFAULT_CSP: &str = "default-src 'self'; \
+     script-src 'self'; \
+     style-src 'self' 'unsafe-inline'; \
+     img-src 'self' data: https:; \
+     font-src 'self' data:; \
+     connect-src 'self' ws: wss: http: https:; \
+     frame-ancestors 'none'; \
+     base-uri 'self'; \
+     form-action 'self'";
+
+pub async fn security_headers(req: Request, next: Next) -> Response {
+    let mut resp = next.run(req).await;
+    let headers = resp.headers_mut();
+    headers.insert(
+        header::X_CONTENT_TYPE_OPTIONS,
+        HeaderValue::from_static("nosniff"),
+    );
+    headers.insert(
+        header::X_FRAME_OPTIONS,
+        HeaderValue::from_static("DENY"),
+    );
+    headers.insert(
+        header::REFERRER_POLICY,
+        HeaderValue::from_static("no-referrer"),
+    );
+    headers.insert(
+        HeaderName::from_static("permissions-policy"),
+        HeaderValue::from_static("interest-cohort=(), browsing-topics=()"),
+    );
+    headers.insert(
+        header::CONTENT_SECURITY_POLICY,
+        HeaderValue::from_static(DEFAULT_CSP),
+    );
+    resp
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{Router, body::Body, routing::get};
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn middleware_sets_baseline_headers() {
+        let app = Router::new()
+            .route("/x", get(|| async { "ok" }))
+            .layer(axum::middleware::from_fn(security_headers));
+
+        let resp = app
+            .oneshot(
+                axum::http::Request::builder()
+                    .uri("/x")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), 200);
+        let h = resp.headers().clone();
+        assert_eq!(h["x-content-type-options"], "nosniff");
+        assert_eq!(h["x-frame-options"], "DENY");
+        assert_eq!(h["referrer-policy"], "no-referrer");
+        assert!(h.get("content-security-policy").is_some());
+        assert!(h.get("permissions-policy").is_some());
+        // Drain body to keep clippy happy.
+        let _ = resp.into_body().collect().await.unwrap();
+    }
+}

--- a/crates/server/src/security_headers.rs
+++ b/crates/server/src/security_headers.rs
@@ -40,10 +40,7 @@ pub async fn security_headers(req: Request, next: Next) -> Response {
         header::X_CONTENT_TYPE_OPTIONS,
         HeaderValue::from_static("nosniff"),
     );
-    headers.insert(
-        header::X_FRAME_OPTIONS,
-        HeaderValue::from_static("DENY"),
-    );
+    headers.insert(header::X_FRAME_OPTIONS, HeaderValue::from_static("DENY"));
     headers.insert(
         header::REFERRER_POLICY,
         HeaderValue::from_static("no-referrer"),

--- a/crates/server/src/setup.rs
+++ b/crates/server/src/setup.rs
@@ -41,14 +41,15 @@ pub fn setup_router(state: AppState, auth: AuthState) -> Router {
         axum::middleware::from_fn_with_state(auth.clone(), crate::auth::require_setup_pin);
 
     Router::new()
-        .route("/api/v1/setup/complete", post(complete).route_layer(pin_layer))
+        .route(
+            "/api/v1/setup/complete",
+            post(complete).route_layer(pin_layer),
+        )
         .route("/api/v1/setup/status", get(status))
         .with_state((state, auth))
 }
 
-async fn status(
-    State((_app, auth)): State<(AppState, AuthState)>,
-) -> Json<SetupStatus> {
+async fn status(State((_app, auth)): State<(AppState, AuthState)>) -> Json<SetupStatus> {
     Json(SetupStatus {
         needs_setup: !auth.setup_complete().await,
         needs_pin: auth.setup_pin.is_some(),
@@ -90,7 +91,13 @@ async fn complete(
 
     // Issue a session cookie so the wizard can drop the user straight into
     // the app without a separate login round-trip.
-    let session_id = match login::create_session(&app, cfg.server.admin_username.as_deref().unwrap_or(""), cfg.server.session_ttl_secs).await {
+    let session_id = match login::create_session(
+        &app,
+        cfg.server.admin_username.as_deref().unwrap_or(""),
+        cfg.server.session_ttl_secs,
+    )
+    .await
+    {
         Ok(id) => id,
         Err(e) => {
             tracing::error!("setup: session create failed: {e}");

--- a/crates/server/src/static_files.rs
+++ b/crates/server/src/static_files.rs
@@ -40,17 +40,18 @@ async fn serve_static(req: Request) -> Response {
 
     // SPA fallback: serve index.html for all non-file paths
     if (!path.contains('.') || path.is_empty())
-        && let Some(index) = WebUiAssets::get("index.html") {
-            return (
-                StatusCode::OK,
-                [
-                    (header::CONTENT_TYPE, "text/html".to_string()),
-                    (header::CACHE_CONTROL, "no-cache".to_string()),
-                ],
-                index.data.to_vec(),
-            )
-                .into_response();
-        }
+        && let Some(index) = WebUiAssets::get("index.html")
+    {
+        return (
+            StatusCode::OK,
+            [
+                (header::CONTENT_TYPE, "text/html".to_string()),
+                (header::CACHE_CONTROL, "no-cache".to_string()),
+            ],
+            index.data.to_vec(),
+        )
+            .into_response();
+    }
 
     StatusCode::NOT_FOUND.into_response()
 }

--- a/crates/server/src/webhooks.rs
+++ b/crates/server/src/webhooks.rs
@@ -204,6 +204,13 @@ async fn dispatch_once(
     payload_json: &str,
     event_type: &str,
 ) -> Result<u16, String> {
+    // Re-validate the destination at dispatch time so DNS-rebinding can't
+    // bypass the create_webhook gate by changing answers between
+    // configuration and use.
+    crate::net_guard::validate_outbound_url(&endpoint.url, false)
+        .await
+        .map_err(|e| format!("webhook target rejected: {e}"))?;
+
     let delivery_id = uuid::Uuid::new_v4().to_string();
 
     let mut req = client

--- a/crates/server/src/webhooks.rs
+++ b/crates/server/src/webhooks.rs
@@ -188,7 +188,8 @@ async fn dispatch_with_retry(
         }
 
         if attempt < endpoint.retry_count {
-            let delay = Duration::from_secs(endpoint.retry_delay_secs as u64 * (attempt as u64 + 1));
+            let delay =
+                Duration::from_secs(endpoint.retry_delay_secs as u64 * (attempt as u64 + 1));
             tokio::time::sleep(delay).await;
         }
     }

--- a/crates/server/src/ws.rs
+++ b/crates/server/src/ws.rs
@@ -29,9 +29,10 @@ async fn handle_socket(mut socket: axum::extract::ws::WebSocket, state: AppState
             Ok(event) => {
                 // DownloadEvent derives Serialize with tag="type", so we can serialize directly
                 if let Ok(json) = serde_json::to_string(&event)
-                    && socket.send(Message::Text(json.into())).await.is_err() {
-                        break;
-                    }
+                    && socket.send(Message::Text(json.into())).await.is_err()
+                {
+                    break;
+                }
             }
             Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
                 warn!("WebSocket client lagged, skipped {n} events");

--- a/crates/server/tests/api_tests.rs
+++ b/crates/server/tests/api_tests.rs
@@ -795,3 +795,82 @@ async fn test_add_download_with_invalid_json_returns_error() {
 
     assert!(resp.status().is_client_error());
 }
+
+// =============================================================================
+// Body-size limits (audit finding #3 — DoS via unbounded uploads)
+// =============================================================================
+
+#[tokio::test]
+async fn dlc_upload_rejects_oversize_body() {
+    let addr = spawn_test_server().await;
+    let client = test_client();
+
+    // 2 MiB synthetic payload — over the 1 MiB DLC limit. We hand-roll the
+    // multipart body so the test depends only on the JSON-enabled client
+    // used elsewhere. The body-size guard triggers from DefaultBodyLimit
+    // before the multipart parser even runs, so the exact framing does not
+    // matter as long as the wire size exceeds the limit.
+    let payload = vec![b'A'; 2 * 1024 * 1024];
+    let boundary = "----amigotest";
+    let mut body: Vec<u8> = Vec::with_capacity(payload.len() + 256);
+    body.extend_from_slice(format!("--{boundary}\r\n").as_bytes());
+    body.extend_from_slice(
+        b"Content-Disposition: form-data; name=\"file\"; filename=\"evil.dlc\"\r\n",
+    );
+    body.extend_from_slice(b"Content-Type: application/octet-stream\r\n\r\n");
+    body.extend_from_slice(&payload);
+    body.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
+
+    let resp = client
+        .post(format!("{}/api/v1/downloads/container", base_url(addr)))
+        .header(
+            "content-type",
+            format!("multipart/form-data; boundary={boundary}"),
+        )
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+
+    // The body-size guard rejects the request before the handler ever
+    // sees it. The exact status varies (axum's DefaultBodyLimit returns
+    // 413 for raw bodies, the Multipart extractor surfaces it as 400),
+    // but it must not be a 2xx — the must-not is that an oversize body
+    // gets buffered into the handler.
+    let status = resp.status();
+    assert!(
+        status.is_client_error(),
+        "expected 4xx for oversize DLC, got {status}"
+    );
+    assert!(
+        matches!(status.as_u16(), 400 | 413),
+        "expected 400 or 413 for oversize DLC, got {status}"
+    );
+}
+
+#[tokio::test]
+async fn nzb_upload_rejects_oversize_body() {
+    let addr = spawn_test_server().await;
+    let client = test_client();
+
+    // 65 MiB JSON body — over the 64 MiB NZB limit. We stuff the bytes into
+    // the nzb_data field as a long string.
+    let big_string = "X".repeat(65 * 1024 * 1024);
+    let body = serde_json::json!({ "nzb_data": big_string });
+
+    let resp = client
+        .post(format!("{}/api/v1/downloads/nzb", base_url(addr)))
+        .json(&body)
+        .send()
+        .await
+        .unwrap();
+
+    // Either 413 Payload Too Large from DefaultBodyLimit, or a 4xx if the
+    // server rejects the connection earlier — anything in the client-error
+    // range is acceptable; the must-not is "200 OK".
+    assert!(
+        resp.status().is_client_error(),
+        "expected 4xx, got {}",
+        resp.status()
+    );
+}

--- a/crates/server/tests/api_tests.rs
+++ b/crates/server/tests/api_tests.rs
@@ -671,10 +671,7 @@ async fn test_delete_nonexistent_webhook_returns_404() {
     let client = test_client();
 
     let resp = client
-        .delete(format!(
-            "{}/api/v1/webhooks/nonexistent",
-            base_url(addr)
-        ))
+        .delete(format!("{}/api/v1/webhooks/nonexistent", base_url(addr)))
         .send()
         .await
         .unwrap();

--- a/crates/server/tests/api_tests.rs
+++ b/crates/server/tests/api_tests.rs
@@ -874,3 +874,94 @@ async fn nzb_upload_rejects_oversize_body() {
         resp.status()
     );
 }
+
+// =============================================================================
+// SSRF guard (audit finding #7)
+// =============================================================================
+
+#[tokio::test]
+async fn create_webhook_rejects_private_ip_url() {
+    let addr = spawn_test_server().await;
+    let client = test_client();
+
+    let resp = client
+        .post(format!("{}/api/v1/webhooks", base_url(addr)))
+        .json(&serde_json::json!({
+            "name": "evil",
+            "url": "http://127.0.0.1:22/",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 400, "loopback must be rejected");
+
+    let resp = client
+        .post(format!("{}/api/v1/webhooks", base_url(addr)))
+        .json(&serde_json::json!({
+            "name": "metadata",
+            "url": "http://169.254.169.254/latest/meta-data/",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status().as_u16(),
+        400,
+        "AWS metadata IP must be rejected"
+    );
+
+    let resp = client
+        .post(format!("{}/api/v1/webhooks", base_url(addr)))
+        .json(&serde_json::json!({
+            "name": "scheme",
+            "url": "file:///etc/passwd",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status().as_u16(),
+        400,
+        "non-http(s) scheme must be rejected"
+    );
+}
+
+#[tokio::test]
+async fn add_rss_feed_rejects_private_ip_url() {
+    // Build a server with rss_feeds enabled so we exercise the SSRF guard
+    // rather than the feature flag short-circuit.
+    let config = Config {
+        max_concurrent_downloads: 0,
+        features: amigo_core::config::FeatureFlags {
+            rss_feeds: true,
+            ..Default::default()
+        },
+        ..Config::default()
+    };
+    let state = amigo_server::build_test_state(config);
+    let app = amigo_server::build_test_router(state);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    let client = test_client();
+
+    let resp = client
+        .post(format!("{}/api/v1/rss", base_url(addr)))
+        .json(&serde_json::json!({
+            "name": "evil",
+            "url": "http://10.0.0.1/feed.xml",
+            "category": "",
+            "interval_minutes": 60_u32,
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status().as_u16(),
+        400,
+        "RFC1918 RSS URL must be rejected"
+    );
+}

--- a/crates/server/tests/auth_flow_tests.rs
+++ b/crates/server/tests/auth_flow_tests.rs
@@ -66,11 +66,7 @@ fn url(addr: SocketAddr, path: &str) -> String {
 async fn setup_guard_blocks_api_before_wizard() {
     let (addr, _) = spawn(None).await;
     let c = client();
-    let res = c
-        .get(url(addr, "/api/v1/downloads"))
-        .send()
-        .await
-        .unwrap();
+    let res = c.get(url(addr, "/api/v1/downloads")).send().await.unwrap();
     assert_eq!(res.status(), 503);
     let body: serde_json::Value = res.json().await.unwrap();
     assert_eq!(body["error"], "setup_required");

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -18,7 +18,10 @@ COPY web-ui web-ui
 RUN pnpm --filter amigo-web-ui build
 
 # Stage 2: Build Rust
-FROM rust:1-bookworm AS rust-builder
+# Pinning to a minor + dated tag stops a silent base-image bump from
+# changing the toolchain mid-release. Bump deliberately when the project
+# moves to a new MSRV.
+FROM rust:1.94-bookworm AS rust-builder
 RUN apt-get update && apt-get install -y protobuf-compiler libclang-dev && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY Cargo.toml Cargo.lock ./
@@ -28,6 +31,12 @@ COPY --from=ui-builder /app/web-ui/dist web-ui/dist
 RUN cargo build --release --bin amigo-server --bin amigo-dl
 
 # Stage 3: Runtime
+# Stays on the floating bookworm-slim tag so security updates land
+# without manual intervention; rebuilds in CI are reproducible because
+# the rust-builder stage above is pinned and the runtime stage only
+# adds ca-certificates + wget on top. If reproducibility against a
+# specific debian point release matters more than auto-patching, swap
+# the tag for a dated one (e.g. debian:bookworm-20250908-slim).
 FROM debian:bookworm-slim
 
 # Install runtime dependencies (ca-certificates for TLS, wget for healthcheck)

--- a/docs/specs/audit-2026-04-25.md
+++ b/docs/specs/audit-2026-04-25.md
@@ -1,0 +1,624 @@
+# Audit 2026-04-25: Repo-Audit, Triage & Top-Fixes
+
+> Stand der Umsetzung in Branch `claude/code-review-optimization-9U7bA`
+> ist am Ende dieser Datei dokumentiert. Verwende sie als Triage-Referenz
+> für die noch offenen Findings.
+
+## Context
+
+Das Repo wurde parallel über sechs spezialisierte Explore-Agents auditiert:
+`core`, `plugin-runtime`, `server`, `extractors`, `web-ui` + `plugin-sdk`,
+und Build/CI/Tests. Die Rohbefunde wurden anschließend gegen den
+tatsächlichen Code gegengeprüft (zwei false positives entfernt: Rust 2024
+edition ist seit 1.85 stabil und der hier installierte rustc ist 1.94.1;
+Plugin-Storage ist über die Closure-Capture des `plugin_id` korrekt
+isoliert — siehe `host_api.rs:1234,1253,1269`).
+
+Diese Datei ist zweistufig:
+
+1. **Triage** — alle bestätigten Findings, gruppiert nach Crate, mit
+   Severity, `file:line`, Beschreibung und Fix-Richtung.
+2. **Top-Fix-Implementierungen** — für jedes CRITICAL- und ausgewähltes
+   HIGH-Finding ein konkreter Implementierungsschritt inklusive zu
+   ändernder Dateien, neuer Tests und Verifikationsstrategie.
+
+Ziel: Vor dem ersten Production-Release (a) Plugin-Supply-Chain absichern,
+(b) Sandbox-Resource-Limits erzwingen, (c) Server-Endpoints härten (SSRF,
+Upload-Limits, Secret-Leak), (d) Korrektheits-Bugs in
+Chunk-Reassembly/fsync/Resume schließen, (e) ein echtes
+Integration-Test-Harness aufbauen.
+
+---
+
+## Triage-Übersicht
+
+Severity-Skala: **CRITICAL** (Supply-Chain, RCE, Secret-Leak, Datenverlust) ·
+**HIGH** (DoS, Auth-Bypass, Korruption) · **MEDIUM** (Timing/Edge-Case-Defekte,
+fehlende Limits) · **LOW** (Hygiene, kleine UX-/A11y-Lücken).
+
+| #  | Crate          | Datei:Line                           | Severity  | Kurzfassung                                       |
+|----|----------------|--------------------------------------|-----------|---------------------------------------------------|
+| 1  | plugin-runtime | registry.rs:17-21,74                 | CRITICAL  | Ed25519-Public-Key ist `[0u8; 32]`-Placeholder    |
+| 2  | server         | api.rs:797-820 (`GET /config`)       | CRITICAL  | Voller Config-Dump inkl. Tokens/Passwörter        |
+| 3  | server         | api.rs:543-577 (DLC upload)          | CRITICAL  | Multipart ohne Größenlimit → OOM-DoS              |
+| 4  | core           | http.rs:109,220,311,374              | CRITICAL  | `flush()` ohne `sync_all()` → Datenverlust        |
+| 5  | core           | postprocess.rs:162-169 (zip)         | HIGH      | Zip-Slip via Symlink-Entry                        |
+| 6  | core           | chunk.rs:33                          | HIGH      | Integer-Underflow bei `total_size < num_chunks`   |
+| 7  | server         | webhooks.rs:201-233 + api.rs:1003    | HIGH      | Webhook-URL ohne SSRF-Filter                      |
+| 8  | server         | nzbget_api.rs:73-75                  | HIGH      | Auth deaktiviert, wenn user+pass leer             |
+| 9  | server         | clicknload.rs:20-105                 | HIGH      | Port 9666 ohne Auth, akzeptiert beliebige URLs    |
+| 10 | plugin-runtime | host_api.rs:30,236-251               | HIGH      | Cookie-Jar global, keine Plugin-Isolation         |
+| 11 | plugin-runtime | host_api.rs:385-391                  | HIGH      | `storage_set` ohne Quota (1 MB-Limit nicht aktiv) |
+| 12 | plugin-runtime | host_api.rs:256-276                  | HIGH      | ReDoS in `regex_match` (User-Pattern unbegrenzt)  |
+| 13 | plugin-runtime | host_api.rs:489-551                  | HIGH      | HTML-Parser ohne Größenlimit → OOM                |
+| 14 | plugin-runtime | host_api.rs:1680-1707                | HIGH      | `base64Decode` unbegrenzt → Heap-OOM              |
+| 15 | extractors     | youtube/formats.rs:18-20             | HIGH      | Kein Fallback für `signatureCipher`-Formate       |
+| 16 | extractors     | youtube/n_challenge.rs:14-16,287-319 | HIGH      | Player-JS-Cache ohne TTL, QuickJS ohne Timeout    |
+| 17 | core           | coordinator.rs:340-414               | HIGH      | Progress-Channel verloren bei Retry               |
+| 18 | core           | coordinator.rs:98                    | HIGH      | Broadcast-Channel zu klein (256), Lag droppt      |
+| 19 | core           | protocol/usenet/nntp.rs:42,186-196   | HIGH      | NNTP: Hostname unvalidiert, Reads ohne Timeout    |
+| 20 | server         | api.rs (alle POST/DELETE)            | HIGH      | Kein per-Token Rate-Limit                         |
+| 21 | server         | feedback.rs:139-171                  | HIGH      | `/system-info` leakt OS, Plugins, Bandwidth       |
+| 22 | core           | http.rs:210-229                      | MEDIUM    | TOCTOU bei `rename(.part → dest)`                 |
+| 23 | core           | postprocess.rs:410-422               | MEDIUM    | Archive-Pfad nicht gegen `..` geprüft             |
+| 24 | core           | bandwidth.rs:132                     | MEDIUM    | `limit * 2` Overflow                              |
+| 25 | core           | container.rs:28-67                   | MEDIUM    | Eigene Base64-Impl statt `base64`-Crate           |
+| 26 | core           | hls.rs:40 / dash.rs                  | MEDIUM    | Manifest-Fetch folgt 20 Redirects ungeprüft       |
+| 27 | core           | nzb.rs:58-96                         | MEDIUM    | Fehlendes `</file>` → silent-skip                 |
+| 28 | core           | http.rs:79-81                        | MEDIUM    | Kein Disk-Space-Check vor Download                |
+| 29 | extractors     | innertube.rs:62,70                   | MEDIUM    | InnerTube clientVersion 3 Monate alt              |
+| 30 | extractors     | innertube.rs:105-118                 | MEDIUM    | `playabilityStatus` nicht differenziert           |
+| 31 | extractors     | url_parser.rs                        | MEDIUM    | `/live/`, `music.youtube.com` nicht erkannt       |
+| 32 | extractors     | (alle YT-Files)                      | MEDIUM    | `hlsManifestUrl`/`dashManifestUrl` ungenutzt      |
+| 33 | server         | ws.rs:23-44                          | MEDIUM    | Keine Backpressure pro WS-Client                  |
+| 34 | server         | background.rs:244-253                | MEDIUM    | RSS-Feed-URL ohne SSRF-Filter                     |
+| 35 | server         | feedback.rs:337-358                  | MEDIUM    | GitHub-Token kann via reqwest-Debug-Log leaken    |
+| 36 | server         | main.rs:76-96                        | MEDIUM    | `config.toml` mit Hash wird mit umask 022 gespeichert |
+| 37 | web-ui         | App.svelte:249-250                   | MEDIUM    | `popstate`-Listener ohne Cleanup                  |
+| 38 | web-ui         | ContextMenu.svelte:23-28             | MEDIUM    | Keine Pfeil-Navigation, kein Focus-Trap           |
+| 39 | web-ui         | CaptchaDialog/Feedback/Shortcuts     | MEDIUM    | Modals ohne Focus-Trap                            |
+| 40 | web-ui         | lib/stores.ts:8-20, lib/api.ts       | MEDIUM    | TS-Typen handgeschrieben → Drift gegen Rust-DTOs  |
+| 41 | plugin-sdk     | form/form.ts:109-130                 | MEDIUM    | Formular-Parsing per Regex statt DOM              |
+| 42 | tauri          | tauri.conf.json:22                   | MEDIUM    | CSP erlaubt `ws://localhost:*` + `style 'unsafe-inline'` |
+| 43 | tauri          | tauri.conf.json (deep-link)          | MEDIUM    | `magnet:`-Scheme ohne URI-Validation              |
+| 44 | CI             | .github/workflows/ci.yml             | MEDIUM    | Kein `cargo fmt --check`, `cargo audit`, `pnpm audit` |
+| 45 | CI             | release-build.yml                    | MEDIUM    | Keine SLSA-Provenance, keine SBOM, keine Trivy    |
+| 46 | docker         | Dockerfile:2,31                      | MEDIUM    | Base-Images unpinned (`rust:1`, `debian:bookworm-slim`) |
+| 47 | tests          | `tests/integration/`, `tests/plugins/` | MEDIUM  | Beide Verzeichnisse leer                          |
+| 48 | core           | http.rs:225-228                      | LOW       | `.part`-Cleanup nicht geloggt bei Fehler          |
+| 49 | core           | nntp.rs:50-63                        | LOW       | TLS-Cert-Validation nicht explizit erzwungen      |
+| 50 | server         | login.rs:108, setup.rs:100           | LOW       | Cookie ohne `Secure`-Flag bei HTTPS               |
+
+> Falsch eingestufte Audit-Behauptungen (verworfen nach Quellverifikation):
+> – „Rust 2024 edition existiert nicht" — falsch, stabil seit 1.85; lokaler `rustc` ist 1.94.1.
+> – „Plugin-Storage cross-read über `storageGet(plugin_id, key)`" — falsch, `plugin_id` ist
+>   beim `register_host_api` in die Closure gebacken (`host_api.rs:1234,1253,1269`); JS sieht nur `(key, value)`.
+
+---
+
+## Top-Fix-Implementierungen
+
+### Fix #1 — Echter Ed25519-Registry-Key (CRITICAL)
+
+**Datei:** `crates/plugin-runtime/src/registry.rs:17-21,74`
+
+Aktuell: `pub const AMIGO_REGISTRY_PUBLIC_KEY: [u8; 32] = [0u8; 32];` mit
+Kommentar „placeholder". `RegistryConfig::default()` setzt
+`trusted_signing_key = Some(AMIGO_REGISTRY_PUBLIC_KEY)`, also wird in
+Production gegen den Null-Key verifiziert — jeder mit dem entsprechenden
+Null-Private-Key kann gültige Signaturen erzeugen.
+
+**Schritte:**
+1. Offline ein Ed25519-Keypair generieren (`amigo-labs/registry-signing-key`),
+   Private in 1Password/Vault, Public 32 Bytes als Hex/Base64 ablegen.
+2. `registry.rs`: Konstante via `option_env!("AMIGO_REGISTRY_PUBKEY_HEX")` zur
+   Compile-Zeit einlesen; Fallback ist ein `compile_error!`, damit
+   Release-Builds ohne gesetzte Env-Variable nicht durchlaufen.
+3. `build.rs` ergänzen: Wenn `CARGO_CFG_RELEASE_PROFILE` = `release`, prüfen,
+   dass Pubkey ≠ `[0u8; 32]`. Sonst `panic!`.
+4. Tests in Dev-Profile dürfen weiter mit Test-Keys arbeiten —
+   `RegistryConfig::for_test(pubkey)` bereits vorhanden lassen, aber `Default`
+   nur in `cfg(not(test))` mit Production-Key.
+5. Release-Workflow: Pubkey-Hex als GitHub-Secret, in `release-build.yml` als
+   Env exportieren.
+
+**Tests:** neuer Unit-Test `rejects_zero_key()` der prüft, dass Verifikation
+gegen `[0u8; 32]` mit `Err(SignatureError::UntrustedKey)` fehlschlägt;
+`verifies_real_signature()` mit fest eingebettetem Test-Vektor.
+
+---
+
+### Fix #2 — `GET /api/v1/config` redigieren (CRITICAL)
+
+**Datei:** `crates/server/src/api.rs:797-820`
+
+Aktuell wird `Json(config)` blank zurückgegeben. Enthält
+`feedback.github_token`, `server.api_token`, `nzbget_api.username/password`,
+`webhooks[*].secret`.
+
+**Schritte:**
+1. Neue DTO `ConfigPublic` in `crates/server/src/api.rs` (oder eigenes Modul
+   `dto.rs`) — enthält nur nicht-sensitive Felder. Sensitive Felder werden als
+   `bool has_*` exposed (z. B. `feedback_configured: bool`).
+2. `get_config` returnt `ConfigPublic`. `put_config` akzeptiert `ConfigUpdate`
+   mit Optional-Feldern, sodass leere Strings gemeldete Secrets nicht
+   überschreiben (`Option<String>` = `None` → unverändert, `Some("")` →
+   löschen, `Some(v)` → setzen).
+3. Sicherheitsnetz: Serde-Test, der `ConfigPublic`-JSON gegen Pflicht-Blacklist
+   scannt („github_token", „api_token", „password", „secret", „token") und
+   failed.
+4. UI (`web-ui/src/pages/Settings.svelte`) anpassen, sodass Secret-Felder als
+   „••••" mit „Replace"-Button laufen.
+
+**Tests:** `crates/server/tests/api_tests.rs` erweitern um
+`config_endpoint_redacts_secrets()`.
+
+---
+
+### Fix #3 — Multipart-Upload-Limit (CRITICAL)
+
+**Datei:** `crates/server/src/api.rs:543-577` (`upload_container`) plus
+globaler Layer.
+
+**Schritte:**
+1. Globaler `RequestBodyLimitLayer::new(MAX_BODY_BYTES)` (z. B. 16 MiB Default)
+   auf den Router anwenden — `tower-http` bringt das mit.
+2. Für Endpunkte, die größere Bodies brauchen (NZB-Import, DLC-Import) eine
+   eigene Subroute mit eigenem Limit (z. B. 64 MiB für NZB, 1 MiB für DLC;
+   DLC-Container sind selten > einige KB).
+3. In `upload_container`: Stream-basierte Verarbeitung
+   (`field.bytes_stream()` statt `field.bytes().await`), pro Chunk Counter,
+   Abbruch bei Überschreitung mit `413 Payload Too Large`.
+4. Konfigurierbar via `config.server.max_upload_bytes`.
+
+**Tests:** `api_tests.rs` — Upload mit `MAX + 1` Bytes muss `413` liefern,
+ohne den Server zu OOMen.
+
+---
+
+### Fix #4 — `sync_all()` nach kritischen Writes (CRITICAL)
+
+**Datei:** `crates/core/src/protocol/http.rs` (Zeilen 109, 220, 311, 374) und
+`crates/core/src/chunk.rs` (Reassembly-Stelle).
+
+**Schritte:**
+1. Vor jedem `rename(.part → final)` und nach jeder Chunk-Persistierung:
+   `file.sync_all().await?`.
+2. Helper `async fn fsync_then_close(file: tokio::fs::File) -> io::Result<()>`
+   einführen, der den Vorgang an einer Stelle bündelt.
+3. Auf Linux/macOS reicht `sync_all`; für Windows zusätzlich `flush_async`
+   davor.
+4. Performance: nur am Ende eines Chunks und vor Rename — nicht pro
+   `write_all`-Call.
+
+**Tests:** `core/tests/coordinator.rs` ergänzen um
+`resume_after_simulated_crash`, der mit einer `tempfile`-Sandbox einen partial
+download anlegt, das Programm „crasht" (drop), neu startet und verifiziert,
+dass die Bytes auf Disk == State in DB sind.
+
+---
+
+### Fix #5 — Zip-Slip via Symlink schließen (HIGH)
+
+**Datei:** `crates/core/src/postprocess.rs:162-169` (ZIP); analog für 7z, RAR,
+tar.
+
+**Schritte:**
+1. Vor jedem Extract-Write den vollständigen `out_path` mit
+   `path_clean::clean()` normalisieren und prüfen, dass er nach
+   `output_dir.canonicalize()` weiterhin unter `output_dir` liegt.
+2. Symlink-Einträge (ZIP `S_IFLNK`, tar `LNKTYPE`/`SYMTYPE`) komplett
+   ignorieren — Whitelist: nur reguläre Dateien und Verzeichnisse extrahieren.
+3. Vor `File::create(&out_path)` prüfen, ob ein Eltern-Pfad-Segment ein
+   bereits existierendes Symlink ist (`symlink_metadata().is_symlink()`);
+   falls ja, Extract abbrechen.
+4. Helper `safe_extract_path(base: &Path, entry_name: &str) ->
+   Result<PathBuf, ExtractError>` einführen und in allen vier Backends (zip,
+   sevenz, unrar, tar/gz) verwenden.
+
+**Tests:** `core/tests/postprocess_zip_slip.rs` — drei Fixtures: regulärer
+Zip, Pfad-Traversal-Zip (`../../etc/passwd`), Symlink-Zip. Alle drei müssen
+erkannt und blockiert werden.
+
+---
+
+### Fix #6 — Chunk-Size-Underflow (HIGH)
+
+**Datei:** `crates/core/src/chunk.rs:33`
+
+Aktuell: `let chunk_size = total_size / num_chunks as u64;` — bei
+`total_size < num_chunks` wird `chunk_size = 0`, der nicht-letzte
+Chunk-`end = start + 0 - 1` wrappt zu `u64::MAX`.
+
+**Schritte:**
+1. Anzahl Chunks dynamisch begrenzen:
+   `let n = num_chunks.min(total_size.max(1) as usize);`
+2. `chunk_size = total_size.div_ceil(n as u64)` (stable seit 1.73).
+3. Edge-Case `total_size == 0`: einen einzelnen 0-Byte-Chunk erzeugen statt
+   leerer Liste.
+4. Range-Header: `bytes=start-end` mit
+   `end = (start + chunk_size - 1).min(total_size - 1)`.
+
+**Tests:** Property-basiert via `proptest` — für beliebige
+`(total_size, num_chunks)` muss `Σ chunk.len() == total_size`, alle Ranges
+disjunkt, keine Range > `total_size`.
+
+---
+
+### Fix #7 — Webhook-/RSS-SSRF-Filter (HIGH)
+
+**Dateien:** `crates/server/src/webhooks.rs:201-233`,
+`crates/server/src/api.rs:1003-1019`, `crates/server/src/background.rs:244-253`.
+
+**Schritte:**
+1. Neues Modul `crates/server/src/net_guard.rs` mit
+   `pub fn validate_outbound_url(url: &Url) -> Result<(), GuardError>`.
+2. Schema-Whitelist: nur `https`, `http` (Letzteres optional via
+   `config.server.allow_http_webhooks`).
+3. DNS-Resolution direkt vor dem Senden (`tokio::net::lookup_host`); jede
+   aufgelöste IP gegen private/loopback/link-local prüfen (`ip_network`-Crate).
+   Block: `127.0.0.0/8`, `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`,
+   `169.254.0.0/16`, `::1`, `fc00::/7`, `fe80::/10`.
+4. Reqwest-Client mit `resolve_to_addrs` aus dem geprüften IP-Set rebuilden
+   (verhindert DNS-Rebinding zwischen Validation und Request).
+5. Konfigurierbare Allowlist (`config.webhooks.allowed_hosts`) für legitime
+   interne Targets.
+
+**Tests:** `tests/integration/ssrf_guard.rs` mit echtem TCP-Listener auf
+`127.0.0.1:0`, der von der Webhook-Dispatcher-API NICHT erreicht werden darf.
+
+---
+
+### Fix #8 — NZBGet-Auth darf nicht „leer = offen" sein (HIGH)
+
+**Datei:** `crates/server/src/nzbget_api.rs:73-75`
+
+Aktuell:
+`if expected_user.is_empty() && expected_pass.is_empty() { return true; }`.
+
+**Schritte:**
+1. Logik umdrehen: Wenn beide leer sind, NZBGet-Router gar nicht erst mounten
+   (Default = aus).
+2. Wenn aktiviert (`config.nzbget_api.enabled = true`), beide Felder Pflicht
+   — Startup-Check in `main.rs`, der mit klarem Error abbricht.
+3. Defense-in-depth: NZBGet-Router auch hinter `auth_layer` einhängen.
+4. Brute-Force-Limiter: max 5 fehlgeschlagene Logins / 60 s pro Source-IP,
+   30 s Lockout (Backbone des allgemeinen Rate-Limit-Layers aus Fix #15).
+
+**Tests:** `nzbget_auth_tests.rs` — Fälle: disabled (404), enabled+richtige
+Creds (200), enabled+falsche Creds (401), enabled+leere Creds in Header (401),
+Konfig mit beiden leer → Startup-Error.
+
+---
+
+### Fix #9 — Click'n'Load absichern (HIGH)
+
+**Datei:** `crates/server/src/clicknload.rs:20-105`
+
+**Schritte:**
+1. Bind-Adresse zwingend `127.0.0.1` bleibt; Startup-Assertion ergänzen.
+2. CORS für Port 9666: `Access-Control-Allow-Origin` nur für die
+   JDownloader-Browser-Extension-IDs der gängigen Browser. Origin-Header-
+   Whitelist prüfen.
+3. Optionaler PSK-Token: `config.clicknload.shared_secret`. Wenn gesetzt,
+   muss Header `X-Amigo-CnL-Token` mit konstantzeitigem
+   `subtle::ConstantTimeEq` matchen.
+4. URLs vor dem Queueing durch `validate_outbound_url` aus Fix #7 (keine
+   `file:`/`gopher:`/private-IP-Ziele).
+5. Rate-Limit: 60 Requests / Minute per IP.
+
+**Tests:** `clicknload_tests.rs` — Loopback-Origin-Whitelist, PSK-Mismatch,
+file://-Reject.
+
+---
+
+### Fix #10 — Cookie-Jar pro Plugin (HIGH)
+
+**Datei:** `crates/plugin-runtime/src/host_api.rs:30,236-251`
+
+Aktuell: `cookies: Arc<Mutex<HashMap<String /*domain*/, HashMap<String /*name*/, String>>>>`
+ist global. Plugin A kann via `getCookie("real-debrid.com", "auth")` das
+Token von Plugin B lesen.
+
+**Schritte:**
+1. Storage-Schema ändern: `cookies: Arc<Mutex<HashMap<String /*plugin_id*/,
+   HashMap<String, HashMap<String, String>>>>>`.
+2. `set_cookie/get_cookie/clear_cookies` nehmen zusätzlich `plugin_id: &str`
+   (analog zu `storage_*`).
+3. JS-Bindings in `register_host_api` analog zu `storageGet`: `plugin_id`
+   per Closure-Capture binden, JS-API bleibt unverändert.
+4. Migration: in der ersten Version sind Cookies sowieso In-Memory — kein
+   DB-Migration nötig.
+5. HTTP-Backend in Host-API: pro Plugin einen `reqwest::cookie::Jar` aus dem
+   Per-Plugin-Cookie-Map befüllen, bevor der Request raus geht.
+
+**Tests:** `host_api_tests.rs::cookies_isolated_between_plugins()`.
+
+---
+
+### Fix #11 — Resource-Limits in Host-API erzwingen (HIGH)
+
+**Dateien:** `crates/plugin-runtime/src/host_api.rs`,
+`crates/plugin-runtime/src/sandbox.rs`.
+
+**Schritte:**
+1. `fn enforce_input_limit(name: &str, len: usize, max: usize) -> Result<(), Error>`.
+2. `storage_set`: Track per-plugin total bytes; bei
+   `current + new > sandbox.max_storage_bytes` → `Err(Error::QuotaExceeded)`.
+3. `base64_decode`: Input-Limit `sandbox.max_string_bytes` (Default 4 MiB).
+4. `html_query_*`: Input-Limit `sandbox.max_html_bytes` (Default 8 MiB).
+5. `regex_match/all/replace/split`: Pattern-Länge ≤ 1 KiB; `text.len()` ≤
+   `max_string_bytes`; Compile mit
+   `regex::RegexBuilder::size_limit(1 MiB).dfa_size_limit(2 MiB)`.
+6. `search_json`: Input-Window auf 4 MiB; balanced-brace-Scan abbrechen nach
+   `max_html_bytes`.
+7. Resultat-Limits: `html_query_all` cap 10 000 Treffer.
+
+**Tests:** für jede Funktion ein `oversize_input_returns_quota_exceeded`
+Test; `storage_quota_enforced` mit 100 × 100 KiB = 10 MiB → erster Write
+nach Quota muss fehlschlagen.
+
+---
+
+### Fix #12 — YouTube `signatureCipher`-Fallback (HIGH)
+
+**Datei:** `crates/extractors/src/youtube/formats.rs:18-20`, `n_challenge.rs`.
+
+**Schritte:**
+1. In `parse_format`: zusätzlich `signatureCipher`-Feld parsen (URL-decoded
+   `s=…&sp=sig&url=…`).
+2. Bestehende QuickJS-Pipeline in `n_challenge.rs` erweitern: aus dem
+   Player-JS auch die `decipher`-Funktion extrahieren. Pattern-Liste mit
+   historischen Varianten, primär + 2 Fallbacks.
+3. Kombinieren: zuerst `decipher(s)` → `sig`, dann `n` transformieren wie
+   bisher, dann finalen URL-Querystring zusammenbauen.
+4. Player-JS-Cache: `Arc<DashMap<String, (String, Instant)>>` mit 24 h TTL,
+   max 8 Einträge, LRU-Eviction.
+5. QuickJS-Timeout: `Runtime::set_interrupt_handler` mit 5 s Deadline;
+   OOM-Handler via `set_memory_limit(16 MiB)`.
+
+**Tests:** `extractors/tests/youtube_decipher.rs` mit fixierten
+Player-JS-Snippets aus den letzten 3 YouTube-Versionen.
+
+---
+
+### Fix #13 — Coordinator-Channels gehärtet (HIGH)
+
+**Datei:** `crates/core/src/coordinator.rs:98,340-414`
+
+**Schritte:**
+1. Broadcast-Buffer von 256 → 4096; bei `RecvError::Lagged(n)` zusätzlich
+   Telemetry-Counter (`events_dropped_total`).
+2. Progress-Watch-Channel pro Download wird einmalig im Coordinator angelegt
+   und über alle Retries hinweg geteilt; nicht in der Retry-Schleife neu
+   erzeugen.
+3. Cancel-Channel: `tokio::sync::Notify` statt `oneshot` — übersteht
+   mehrfache Retries und mehrere Listener (UI + Coordinator).
+4. `cancel(id)`: erst Status auf `Cancelled` in DB persistieren, dann
+   Notify, dann nach Worker-Exit aus `active`-Map entfernen — kein TOCTOU.
+
+**Tests:** `coordinator.rs::progress_visible_after_retry`,
+`cancel_during_retry_clean_state`.
+
+---
+
+### Fix #14 — NNTP-Hardening (HIGH)
+
+**Datei:** `crates/core/src/protocol/usenet/nntp.rs:42,50-63,186-196`
+
+**Schritte:**
+1. Hostname-Validation vor `TcpStream::connect`: nur DNS-Label/IP-Literale;
+   Schema-Präfixe (`://`, `/`) verbieten.
+2. TLS-Connector explizit konfigurieren — `danger_accept_invalid_*`
+   defensiv auf `false`.
+3. `tokio::time::timeout(Duration::from_secs(60), …)` um jeden `read_line`
+   und `write_all`.
+4. Optional `config.usenet.tls_pin_sha256` für Cert-Pinning gegen MITM.
+5. Connection-Pool: max idle 5 min, danach `QUIT` und neu verbinden.
+
+**Tests:** Mock-NNTP-Server mit künstlicher Stall-Situation, muss in
+`read_timeout` enden statt zu hängen.
+
+---
+
+### Fix #15 — Per-Token-Rate-Limit + Security-Headers (HIGH)
+
+**Datei:** neuer `crates/server/src/middleware/rate_limit.rs`, plus `main.rs`
+Layer-Setup.
+
+**Schritte:**
+1. `tower_governor` oder eigenes
+   `Arc<Mutex<HashMap<TokenHash, RateState>>>` mit Token-Bucket (60 req/min,
+   Burst 30) per API-Token; bei nicht-authentifizierten Routen per Source-IP.
+2. Security-Headers-Middleware setzt: `X-Content-Type-Options: nosniff`,
+   `X-Frame-Options: DENY`, `Referrer-Policy: no-referrer`,
+   `Content-Security-Policy: default-src 'self'; …`,
+   `Strict-Transport-Security` nur wenn HTTPS detected.
+3. `Cookie::secure(true)` setzen, wenn `request.is_secure()` (oder
+   `X-Forwarded-Proto: https` und `config.server.trust_proxy`).
+
+**Tests:** `rate_limit_blocks_after_burst`, `headers_present_on_all_routes`.
+
+---
+
+### Fix #16 — Web-UI: Listener-Cleanup, Focus-Trap, Typen aus OpenAPI (MEDIUM/HIGH)
+
+**Dateien:** `web-ui/src/App.svelte:249-250`, `ContextMenu.svelte`,
+`CaptchaDialog.svelte`, `FeedbackDialog.svelte`, `ShortcutsDialog.svelte`,
+`lib/stores.ts`, `lib/api.ts`.
+
+**Schritte:**
+1. `popstate`-Handler in eine `onMount`-Komponente verschieben mit
+   `removeEventListener` im Cleanup.
+2. `ContextMenu.svelte`: ↑/↓-Navigation, `Enter`/`Space` zum Aktivieren,
+   `Esc` zum Schließen, `aria-activedescendant`. Focus auf erstes Item beim
+   Öffnen.
+3. Generischer `<Modal>`-Wrapper mit Focus-Trap (focusable elements query,
+   `Tab`/`Shift+Tab` wrap, Restore Previous Focus on Close).
+   Captcha/Feedback/Shortcuts darauf umstellen.
+4. OpenAPI-Schema aus Rust generieren (`utoipa` für Axum-Routen), in CI als
+   `crates/server/openapi.json` committen; `pnpm --filter amigo-web-ui
+   openapi:gen` läuft `openapi-typescript` und schreibt nach
+   `web-ui/src/lib/api.gen.ts`. CI-Check, dass die Datei unverändert ist.
+
+**Tests:** Vitest in `web-ui` (Komponenten-Smoke-Tests);
+Playwright-A11y-Suite (`@axe-core/playwright`) für die drei Modals und das
+Context-Menü.
+
+---
+
+### Fix #17 — CI/CD-Hygiene (MEDIUM)
+
+**Datei:** `.github/workflows/ci.yml`, neuer `release-build.yml`-Step.
+
+**Schritte:**
+1. Job `rustfmt`: `cargo fmt --all -- --check`.
+2. Job `cargo-deny`: `EmbarkStudios/cargo-deny-action@v2` mit `deny.toml`
+   für advisories, bans, licenses, sources.
+3. Job `pnpm-audit`: `pnpm audit --audit-level moderate`.
+4. Job `docker-scan`: `aquasecurity/trivy-action@master` auf das gebaute
+   Image, fail bei HIGH/CRITICAL.
+5. SLSA-Provenance: `actions/attest-build-provenance@v2` für Binaries und
+   Docker-Image.
+6. SBOM: `anchore/sbom-action@v0` (CycloneDX) als Release-Artifact.
+7. Dockerfile pinnt Base-Images: `rust:1.94-bookworm` und
+   `debian:bookworm-20250908-slim`.
+
+**Tests:** PRs gegen einen vorbereiteten Branch mit absichtlichem `unwrap()`
+in Format-Fehler-Form müssen rot werden.
+
+---
+
+### Fix #18 — Integration-Test-Harness (MEDIUM)
+
+**Dateien:** `tests/integration/` (leer), `tests/plugins/` (leer).
+
+**Schritte:**
+1. `tests/integration/Cargo.toml` als eigenständiger Workspace-Member mit
+   `amigo-server`, `amigo-core`, `tempfile`, `httpmock`, `wiremock` als
+   Dev-Deps.
+2. Neue Tests:
+   - `resume_after_crash.rs` — startet HTTP-Server (httpmock) der nach 50 %
+     schließt; Coordinator persistiert State; zweiter Run lädt Rest und
+     matched SHA-256.
+   - `dlc_decrypt_export_roundtrip.rs` — DLC enc → dec → enc identisch.
+   - `captcha_pipeline.rs` — Plugin meldet Captcha, Test-Client solved via
+     REST, Plugin erhält Antwort.
+   - `signature_verify_real_key.rs` — Manifest mit fake key abgelehnt, mit
+     pinned key akzeptiert.
+   - `chunk_merge_corruption.rs` — manueller Bit-Flip in Chunk-Datei →
+     Reassembly muss fehlschlagen mit Hash-Mismatch.
+3. `tests/plugins/`: Smoke-Test, der jedes Plugin in `plugins/hosters/`,
+   `plugins/multi-hosters/`, `plugins/extractors/` lädt, transpiliert, gegen
+   den Sandbox-Limits testet, und die exportierten Pflicht-Felder validiert.
+
+**Tests:** sind selbst der Fix.
+
+---
+
+## Verifikation (End-to-End)
+
+Nach Implementierung der Top-Fixes #1–#18:
+
+1. **Build/Lint:** `cargo fmt --all -- --check`,
+   `cargo clippy --workspace --all-targets -- -D warnings`, `pnpm -r check`.
+2. **Unit-/Integration-Tests:** `cargo test --workspace --all-targets`,
+   `pnpm --filter @amigo/plugin-sdk test`, `pnpm --filter amigo-web-ui test`.
+3. **Security-Tests:**
+   - `cargo deny check`, `cargo audit`, `pnpm audit --audit-level moderate`.
+   - `trivy image amigo-downloader:dev` → 0 HIGH/CRITICAL.
+4. **Smoke-Run:**
+   - `docker compose -f docker/docker-compose.local.yml up`.
+   - Web-UI auf `http://localhost:1516` öffnen, Pairing durchlaufen.
+   - `GET /api/v1/config` muss `github_token`, `api_token`, `password`,
+     `secret` NICHT enthalten.
+   - DLC-Upload mit 100 MiB-Datei → `413 Payload Too Large`.
+   - Webhook auf `http://127.0.0.1:22` → `400 Bad Request` (SSRF-Guard).
+   - NZBGet-API ohne gesetzte Creds → 404 (Router gar nicht gemountet).
+   - 100 parallele Downloads à 50 MiB von einem httpmock-Server, Prozess via
+     `kill -9` stoppen, neu starten — alle resumen, finale SHA-256 stimmen.
+5. **Plugin-Sandbox-Tests:**
+   - Test-Plugin, das `amigo.regexMatch("(a+)+$", "a".repeat(40))` aufruft →
+     muss innerhalb des Sandbox-Timeouts (5 s) abbrechen, nicht den
+     Host-Thread blockieren.
+   - Test-Plugin, das `amigo.storageSet(k, "x".repeat(2_000_000))` 10× ruft
+     → letzter Call muss `QuotaExceeded`.
+6. **Registry-Verify:**
+   - Release-Build ohne `AMIGO_REGISTRY_PUBKEY_HEX` → `compile_error!` /
+     Build-Failure.
+   - Release-Build mit echtem Pubkey → Plugin signed mit fremdem Key wird
+     abgelehnt.
+7. **Web-UI A11y:** Playwright-`@axe-core` durch alle Modals + Kontextmenü,
+   0 violations in `serious`/`critical`.
+
+---
+
+## Reihenfolge / Empfohlene Umsetzung
+
+Phasenweise PRs, jeder PR isoliert grün:
+
+1. **PR-A „Plugin Supply Chain"** — Fix #1 (Ed25519-Key) + #11-Auszug
+   (Storage-Quota).
+2. **PR-B „Server-Hardening"** — Fix #2 (Config-Redact), #3 (Upload-Limit),
+   #7 (SSRF), #8 (NZBGet), #9 (Click'n'Load), #15 (Rate-Limit/Headers).
+3. **PR-C „Core-Korrektheit"** — Fix #4 (fsync), #5 (Zip-Slip),
+   #6 (Chunk-Underflow), #13 (Coordinator-Channels), #14 (NNTP).
+4. **PR-D „Sandbox-Resource-Limits"** — restlicher Fix #11 + Fix #10
+   (Cookie-Isolation).
+5. **PR-E „YouTube"** — Fix #12 (signatureCipher + Player-JS-TTL +
+   QuickJS-Timeout).
+6. **PR-F „UI/SDK"** — Fix #16 (Listener, Focus-Trap, OpenAPI-Typen).
+7. **PR-G „CI/Tests"** — Fix #17 (CI-Hygiene), #18 (Integration-Tests).
+
+Total geschätzter Aufwand: ~3–4 Personenwochen für PR-A bis -G; danach kann
+die Triage-Liste für die verbleibenden MEDIUM/LOW-Findings sukzessive
+abgearbeitet werden.
+
+---
+
+## Umsetzungsstand (Branch `claude/code-review-optimization-9U7bA`)
+
+20 Commits gepusht (alle Tests grün, `clippy -D warnings` und
+`fmt --check` clean).
+
+**Geliefert:**
+
+| PR | Commit | Finding | Severity |
+|----|--------|---------|----------|
+| A | `e2a2d48` `fix(plugin-runtime): inject registry Ed25519 pubkey at compile time` | #1 | CRITICAL |
+| A | `a9d6db8` `fix(plugin-runtime): enforce per-plugin storage quota` | #11 (Storage) | HIGH |
+| B | `868d3c7` `fix(server): close NZBGet JSON-RPC auth bypass` | #8 | HIGH |
+| B | `dc8113d` `fix(server): redact secrets in GET /api/v1/config` | #2 | CRITICAL |
+| B | `050481c` `fix(server): cap upload body size for /downloads/nzb and /downloads/container` | #3 | CRITICAL |
+| B | `517f40d` `fix(server): SSRF guard for webhook + RSS outbound URLs` | #7, #34 | HIGH |
+| B | `96d5ac5` `fix(server): URL allowlist + body cap on Click'n'Load endpoints` | #9 | HIGH |
+| B | `f2e6b5d` `fix(server): apply baseline security headers to every response` | #15 (Headers) | HIGH |
+| C | `928e9cf` `fix(core/http): fsync downloaded files before declaring success` | #4 | CRITICAL |
+| C | `6618743` `fix(core/chunk): kill the underflow in ChunkPlan::split` | #6 | HIGH |
+| C | `aee87db` `fix(core/postprocess): block ZIP-Slip via symlink entries` | #5 | HIGH |
+| C | `f5c792b` `fix(core/nntp): hostname validation, IO timeouts, explicit TLS verify` | #14, #19, #49 | HIGH/LOW |
+| C | `9e36ef8` `fix(core/coordinator): bigger event buffer, share progress channel across retries` | #17, #18 | HIGH |
+| D | `4aff9a2` `fix(plugin-runtime): per-plugin cookie jars` | #10 | HIGH |
+| D | `d8c0982` `fix(plugin-runtime): cap regex / HTML / base64 inputs` | #11, #12, #13, #14 | HIGH/MEDIUM |
+| E | `ee69510` `fix(extractors/youtube): TTL + LRU on player-JS cache, deadline on QuickJS` | #16 | HIGH |
+| G | `2b589af` `style(workspace): apply cargo fmt --all` | – | – |
+| G | `9194a47` `chore(ci,docker): rustfmt check, audit jobs, pinned rust base image` | #44, #45, #46 | MEDIUM |
+| F | `9088dc7` `fix(web-ui): cleanup popstate listener via onMount lifecycle` | #37 | MEDIUM |
+| F | `5e2efd8` `fix(web-ui): keyboard-operable context menu` | #38 | MEDIUM |
+
+**Ergebnis:** 4/4 CRITICAL, 11/17 HIGH, 5/30 MEDIUM adressiert.
+
+**Bewusst zurückgestellt** (mit Begründung im jeweiligen Commit):
+
+| Finding | Begründung |
+|---------|------------|
+| #15 (Rate-Limit) | Defense-in-depth, kein aktiv ausnutzbarer Bug; eigene PR mit Token-Bucket sinnvoller. |
+| #13 (Cancel-Notify) | Tieferes Refactoring; oneshot bleibt mit erklärendem Kommentar. |
+| #15 (YT signatureCipher) | Braucht Live-YouTube-Fixtures zur Verifikation. |
+| #39 (Modal-Focus-Trap) | Browser-visuelle Verifikation nötig; eigener `<Modal>`-Wrapper. |
+| #40 (OpenAPI-Typegen) | Architektur-Änderung mit utoipa + openapi-typescript. |
+| #18 (Integration-Tests) | Eigene PR mit größerem Scope. |
+| #20–#36 (verbleibende MEDIUM) | Sukzessive nach Priorität. |
+
+Diese Datei dient als Referenz für die nächsten PRs. Beim Bearbeiten bitte
+den Status oben aktualisieren (Commit-SHA + PR).

--- a/tauri/src/main.rs
+++ b/tauri/src/main.rs
@@ -34,9 +34,7 @@ fn main() {
     }
 
     // Initialize logging
-    tracing_subscriber::fmt()
-        .with_env_filter("info")
-        .init();
+    tracing_subscriber::fmt().with_env_filter("info").init();
 
     // Load config
     let config = amigo_core::config::Config::load_auto();
@@ -48,18 +46,14 @@ fn main() {
         .plugin(tauri_plugin_notification::init())
         .plugin(tauri_plugin_deep_link::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
-        .invoke_handler(tauri::generate_handler![
-            cmd_add_download,
-            cmd_get_stats,
-        ])
+        .invoke_handler(tauri::generate_handler![cmd_add_download, cmd_get_stats,])
         .setup(move |app| {
             // Resolve platform data dir via Tauri v2 API
             let data_dir = app
                 .path()
                 .app_data_dir()
                 .unwrap_or_else(|_| PathBuf::from("."));
-            std::fs::create_dir_all(&data_dir)
-                .expect("Failed to create app data directory");
+            std::fs::create_dir_all(&data_dir).expect("Failed to create app data directory");
             let db_path = data_dir.join("amigo.db");
             let download_dir = PathBuf::from(&config.download_dir);
             let temp_dir = PathBuf::from(&config.temp_dir);
@@ -85,7 +79,8 @@ fn main() {
                     // Start Click'n'Load listener on port 9666
                     let cnl_coord = coord.clone();
                     tokio::spawn(async move {
-                        if let Err(e) = amigo_server::clicknload::start_clicknload(cnl_coord).await {
+                        if let Err(e) = amigo_server::clicknload::start_clicknload(cnl_coord).await
+                        {
                             tracing::warn!("Click'n'Load failed to start: {e}");
                         }
                     });

--- a/web-ui/src/App.svelte
+++ b/web-ui/src/App.svelte
@@ -43,6 +43,7 @@
     updateDownloadProgress,
     updateDownloadStatus,
     wsConnected,
+    attachRouterPopstateListener,
     type CaptchaChallenge,
     type ColorPalette,
     type Page,
@@ -205,9 +206,15 @@
       loadData();
     });
 
+    // Hash-based router: attached here so HMR / component teardown doesn't
+    // leak `popstate` listeners on `window`. Previously the listener was
+    // registered once at module-init time with no removal path.
+    const detachPopstate = attachRouterPopstateListener();
+
     return () => {
       clearInterval(interval);
       ws.close();
+      detachPopstate();
     };
   });
 

--- a/web-ui/src/components/ContextMenu.svelte
+++ b/web-ui/src/components/ContextMenu.svelte
@@ -1,11 +1,13 @@
 <script lang="ts">
-  import { onMount } from "svelte";
+  import { onMount, tick } from "svelte";
   import Icon from "@amigo/ui/components/Icon.svelte";
 
   let { x, y, items, onclose }:
     { x: number; y: number; items: { label: string; icon: string; action: () => void; color?: string }[]; onclose: () => void } = $props();
 
   let menuEl: HTMLDivElement | undefined = $state();
+  let itemEls: HTMLButtonElement[] = $state([]);
+  let focusedIndex: number = $state(0);
 
   onMount(() => {
     // Adjust position if menu overflows viewport
@@ -18,10 +20,49 @@
         menuEl.style.top = `${window.innerHeight - rect.height - 8}px`;
       }
     }
+    // Focus the first item so the menu is keyboard-operable from the
+    // moment it opens (audit #38).
+    tick().then(() => itemEls[0]?.focus());
   });
 
+  function moveFocus(delta: number) {
+    if (!items.length) return;
+    focusedIndex = (focusedIndex + delta + items.length) % items.length;
+    itemEls[focusedIndex]?.focus();
+  }
+
   function handleKeydown(e: KeyboardEvent) {
-    if (e.key === "Escape") onclose();
+    switch (e.key) {
+      case "Escape":
+        e.preventDefault();
+        onclose();
+        break;
+      case "ArrowDown":
+        e.preventDefault();
+        moveFocus(1);
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        moveFocus(-1);
+        break;
+      case "Home":
+        e.preventDefault();
+        focusedIndex = 0;
+        itemEls[0]?.focus();
+        break;
+      case "End":
+        e.preventDefault();
+        focusedIndex = items.length - 1;
+        itemEls[focusedIndex]?.focus();
+        break;
+      case "Enter":
+      case " ":
+        // Let the active item handle Enter via its onclick. We only need
+        // to ensure that pressing Enter on an item that has just been
+        // moved into focus actually fires it; default browser behaviour
+        // does that, so nothing to add here.
+        break;
+    }
   }
 </script>
 
@@ -36,11 +77,15 @@
   class="fixed z-[61] py-1 rounded-lg shadow-xl min-w-[160px]"
   style="left: {x}px; top: {y}px; background: var(--bg-surface); border: 1px solid var(--border-color)"
   role="menu"
+  aria-orientation="vertical"
 >
-  {#each items as item}
+  {#each items as item, i}
     <button
+      bind:this={itemEls[i]}
       role="menuitem"
+      tabindex={focusedIndex === i ? 0 : -1}
       onclick={() => { item.action(); onclose(); }}
+      onfocus={() => (focusedIndex = i)}
       class="w-full flex items-center gap-2.5 px-3 py-2 text-sm transition-colors text-left"
       style="color: {item.color || 'var(--text-primary)'}"
       onmouseenter={(e) => (e.currentTarget as HTMLElement).style.background = 'var(--hover-bg)'}

--- a/web-ui/src/lib/stores.ts
+++ b/web-ui/src/lib/stores.ts
@@ -238,7 +238,8 @@ function pageFromHash(): Page {
 export const currentPage = writable<Page>(pageFromHash());
 export const protocolFilter = writable<ProtocolFilter>("all");
 
-// Sync URL hash
+// Sync URL hash on every page change (subscriptions have no teardown
+// concern — Svelte stores keep the subscription as long as the store lives).
 if (typeof window !== "undefined") {
   currentPage.subscribe((page) => {
     if (location.hash !== `#${page}`) {
@@ -246,9 +247,30 @@ if (typeof window !== "undefined") {
     }
     document.title = `${page.charAt(0).toUpperCase() + page.slice(1)} — amigo-downloader`;
   });
-  window.addEventListener("popstate", () => {
+}
+
+/**
+ * Wire the browser's `popstate` event to the {@link currentPage} store.
+ *
+ * Returns an unsubscriber that removes the listener. Call from a Svelte
+ * component's `onMount` and surface the returned function as the cleanup,
+ * so HMR / component teardown / tests don't leak listeners on `window`.
+ *
+ * Previous code attached the listener at module-init time with no removal
+ * path. In production that's a singleton (one tab, one window), but during
+ * HMR each module reload would stack another listener on `window`.
+ */
+export function attachRouterPopstateListener(): () => void {
+  if (typeof window === "undefined") {
+    return () => {};
+  }
+  const handler = () => {
     currentPage.set(pageFromHash());
-  });
+  };
+  window.addEventListener("popstate", handler);
+  return () => {
+    window.removeEventListener("popstate", handler);
+  };
 }
 
 // ========================================


### PR DESCRIPTION
## Summary

This PR implements critical and high-priority security fixes from a comprehensive code audit (audit-2026-04-25). The changes address supply-chain integrity, plugin sandbox resource limits, server endpoint hardening (SSRF/upload DoS), data persistence correctness, and input validation across the codebase.

## Key Changes

### Supply-Chain & Plugin Registry (CRITICAL #1)
- **`plugin-runtime/registry.rs`**: Replace all-zero Ed25519 public key placeholder with compile-time injection from `AMIGO_REGISTRY_PUBKEY_HEX` environment variable
- **`plugin-runtime/build.rs`**: Add build-time guard refusing release builds without a real registry key
- Signature verification now fails safely in dev (with warning) instead of trusting a forgeable key

### Plugin Sandbox Resource Limits (HIGH #10, #11, #12, #13, #14)
- **`plugin-runtime/host_api.rs`**: 
  - Implement per-plugin cookie jars (plugin_id → domain → name → value) to prevent cross-plugin cookie leakage
  - Add per-plugin storage quota enforcement (1 MB default, configurable via `SandboxLimits`)
  - Introduce input-size limits for regex patterns (4 KiB), regex text (4 MiB), HTML parsing (8 MiB), and base64 decoding (8 MiB)
  - Compile regexes with NFA/DFA size limits to prevent ReDoS attacks
  - Add `enforce_input_limit` helper and `compile_plugin_regex` wrapper

### Server Upload DoS Prevention (CRITICAL #3)
- **`server/api.rs`**: Add `DefaultBodyLimit` layers to NZB (64 MiB) and DLC (1 MiB) upload endpoints
- Define `MAX_NZB_BODY_BYTES` and `MAX_DLC_BODY_BYTES` constants with rationale comments
- Prevents unbounded multipart buffering from exhausting server memory

### SSRF Protection (HIGH #7, #9, #34)
- **`server/net_guard.rs`** (new): Implement `validate_outbound_url` to guard all outbound HTTP requests
  - Validates URL scheme (http/https only), resolves hostnames, rejects non-public IPs (loopback, RFC1918, link-local, CGNAT, cloud-metadata)
  - Performs DNS resolution at request time (not config save) to prevent DNS-rebinding attacks
  - Mirrors plugin-runtime's IP-blocking policy for consistency
- **`server/nzbget_api.rs`**: Add `validate_nzbget_config` to refuse mounting unauthenticated NZBGet JSON-RPC endpoint when credentials are empty
- **`server/clicknload.rs`**: Add body-size limits (256 KiB for flash/add, 1 MiB for DLC) and route all URLs through `net_guard`

### Data Persistence Correctness (CRITICAL #4)
- **`core/protocol/http.rs`**: Add `fsync_file` helper that calls both `flush()` and `sync_all()` to ensure kernel buffers are persisted to disk
- Apply to all download write paths to prevent data loss on process crash or power failure

### Chunk Reassembly Integer Underflow (HIGH #6)
- **`core/chunk.rs`**: Fix integer underflow when `total_size < num_chunks`
  - Cap actual chunk count at `total_size` (one byte per chunk minimum)
  - Use `div_ceil` to compute chunk size, avoiding the `0` that led to `end = start + 0 - 1 = u64::MAX`
  - Clamp each chunk's `end_byte` to `total_size - 1`
  - Guarantee disjoint, non-overlapping ranges covering `[0, total_size)` exactly once

### Zip Slip Protection (HIGH #5)
- **`core/postprocess.rs`**: Add symlink-entry rejection in `extract_zip`
  - Previous path-

https://claude.ai/code/session_01JEY3aA2Py1ii6s5JM1nLaQ