### PR TITLE
fix(ci): grant packages:write to release-please caller workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  packages: write
 
 jobs:
   release-please:


### PR DESCRIPTION
## Summary

Fixes the workflow validation error:

> Error calling workflow `release-build.yml`. The workflow is requesting `packages: write`, but is only allowed `packages: none`.

The reusable `release-build.yml` workflow needs `packages: write` to push the Docker image to `ghcr.io`. Since reusable workflows (called via `uses:`) inherit permissions from the caller, the caller — `release-please.yml` — must also grant `packages: write`. Its previous permissions block only declared `contents: write` and `pull-requests: write`.

## Changes

- `.github/workflows/release-please.yml`: add `packages: write` to the workflow-level `permissions` block.

## Test plan

- [ ] Push a release-triggering commit to `main` and confirm the `release-please` workflow validates and the downstream `release-build.yml` job runs without the permission error.
- [ ] Confirm the Docker push step (`docker/build-push-action@v6` to `ghcr.io/amigo-labs/amigo-downloader`) succeeds.

https://claude.ai/code/session_01DJQxoa3DCnaiEaYLvMLtZg

---
_Generated by [Claude Code](https://claude.ai/code/session_01DJQxoa3DCnaiEaYLvMLtZg)_