### PR TITLE
docs+chore: release-readiness checklist, package metadata, CLI installer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ version = "0.1.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/amigo-labs/amigo-downloader"
+homepage = "https://github.com/amigo-labs/amigo-downloader"
+authors = ["amigo-labs"]
+description = "Fast, modular download manager in Rust — HTTP, Usenet, HLS/DASH, with a TypeScript plugin system and a responsive Web UI."
 
 [workspace.dependencies]
 # Async runtime

--- a/README.md
+++ b/README.md
@@ -64,6 +64,16 @@ cargo run --release --bin amigo-server
 
 ### CLI
 
+Install the latest pre-built `amigo-dl` binary (Linux/macOS, x86_64/aarch64):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/amigo-labs/amigo-downloader/main/scripts/install.sh | bash
+```
+
+The installer resolves the latest release, verifies its SHA-256 checksum, and
+installs to `/usr/local/bin` (override with `AMIGO_INSTALL_DIR`). Or build from
+source with Cargo:
+
 ```bash
 # Install to ~/.cargo/bin/
 cargo install --path crates/cli

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -3,6 +3,10 @@ name = "amigo-cli"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+authors.workspace = true
+description.workspace = true
+repository.workspace = true
+homepage.workspace = true
 
 [[bin]]
 name = "amigo-dl"

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -3,6 +3,10 @@ name = "amigo-server"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
+authors.workspace = true
+description.workspace = true
+repository.workspace = true
+homepage.workspace = true
 
 [lib]
 name = "amigo_server"

--- a/docs/release-todo.md
+++ b/docs/release-todo.md
@@ -1,0 +1,50 @@
+# Release-TODO — manuelle Schritte zu v1.0
+
+Diese Datei sammelt ausschließlich die **manuell durchzuführenden** Schritte
+auf dem Weg zu einem v1.0-Release — Dinge, die ein Maintainer mit Zugang zu
+Secrets, bezahlten Accounts oder lokalen Signing-Keys erledigen muss. Reine
+Code-Aufgaben (Marketplace-UI, Hoster-Plugins, Rate-Limit, OpenAPI-Codegen,
+Web-UI-Tests, CHANGELOG-Backfill, Rustdoc) gehören **nicht** hierher und
+laufen über eigene PRs.
+
+Stand: v0.1.0 ist getaggt (`236c2a0`), Auto-Release-on-merge ist aktiv, und
+4/4 CRITICAL + 11/17 HIGH aus `docs/specs/audit-2026-04-25.md` sind gemergt.
+
+## Signing & Secrets
+
+- [ ] Tauri-Signing-Key erzeugen (`tauri signer generate`, lokal/offline).
+- [ ] `TAURI_SIGNING_PRIVATE_KEY` und `TAURI_SIGNING_PRIVATE_KEY_PASSWORD`
+      als GitHub-Repo-Secrets hinterlegen (werden in
+      `.github/workflows/release-build.yml` bereits gelesen).
+- [ ] Pubkey in `tauri/tauri.conf.json` gegen den neuen Key abgleichen.
+      Danach kann der Code-Schritt `"active": true` (Updater) gesetzt werden.
+- [ ] Registry-Ed25519-**Private**-Key erzeugen und offline sichern;
+      sicherstellen, dass `AMIGO_REGISTRY_PUBKEY_HEX` (Build-Arg in
+      `.github/workflows/release-build.yml` bzw. Docker-Build) zum
+      Public-Key passt.
+- [ ] Signier-Prozess für den Plugin-Registry-Index etablieren und
+      dokumentieren (wer signiert beim Veröffentlichen neuer Plugins?).
+
+## Accounts & Test-Fixtures (für Verifikation nötig)
+
+- [ ] Bezahlte Test-Accounts für Premiumize und AllDebrid besorgen, um die
+      Plugins unter `plugins/multi-hosters/*` end-to-end zu verifizieren.
+- [ ] Live-YouTube-Fixtures aufnehmen (Player-JS + `signatureCipher`-Sample)
+      für den Fallback-Test zu Audit-Finding #15.
+
+## Veröffentlichung & Distribution
+
+- [ ] Entscheiden, ob `@amigo/plugin-sdk` öffentlich auf npm publiziert wird.
+      Falls ja: npm-Org/Account + `NPM_TOKEN`-Secret anlegen und
+      `"private": true` in `plugin-sdk/package.json` entfernen.
+- [ ] release-please-Release-PR für v1.0 reviewen und mergen (Tag-Cut).
+- [ ] Erstes signiertes Desktop-Bundle manuell auf je einer Plattform
+      (Linux / macOS / Windows) installieren und das Auto-Update von einer
+      heruntergestuften Version aus verifizieren.
+
+## Produkt-Entscheidungen (menschliches Urteil)
+
+- [ ] `docs/specs/docker-security.md`: umsetzen oder begründet für v1.0
+      zurückstellen.
+- [ ] `docs/specs/tauri-workspace-integration.md`: Restscope festlegen,
+      nachdem der Tauri-Updater scharfgeschaltet ist.

--- a/docs/release-todo.md
+++ b/docs/release-todo.md
@@ -7,7 +7,11 @@ Code-Aufgaben (Marketplace-UI, Hoster-Plugins, Rate-Limit, OpenAPI-Codegen,
 Web-UI-Tests, CHANGELOG-Backfill, Rustdoc) gehören **nicht** hierher und
 laufen über eigene PRs.
 
-Stand: v0.1.0 ist getaggt (`236c2a0`), Auto-Release-on-merge ist aktiv, und
+Stand: v0.1.0 ist **noch nicht** getaggt — es existieren keine Git-Tags und
+`.release-please-manifest.json` steht auf `0.0.0`. release-please ist mit
+`release-as: 0.1.0` konfiguriert; der nächste Merge nach `main` öffnet die
+v0.1.0-Release-PR, deren Merge den Tag setzt und den (bewusst leeren)
+`CHANGELOG.md` automatisch füllt. Auto-Release-on-merge ist aktiv, und
 4/4 CRITICAL + 11/17 HIGH aus `docs/specs/audit-2026-04-25.md` sind gemergt.
 
 ## Signing & Secrets


### PR DESCRIPTION
## Summary

Release-readiness work toward v1.0, scoped to changes that are safe to make
autonomously and verifiable here (no secrets, paid accounts, browser, or
architectural rewrites).

- **`docs/release-todo.md`** — checklist of the **manual, maintainer-only**
  steps to a release: signing keys + GitHub secrets, registry Ed25519 key,
  premium-hoster test accounts, npm-publish decision, and a couple of product
  calls. These can't be solved by code in a PR.
- **Workspace package metadata** — added `authors` / `description` / `homepage`
  to `[workspace.package]` and inherited them in the `amigo-server` and
  `amigo-cli` binaries (previously missing). `cargo metadata` validates.
- **README** — documented the one-line `install.sh` installer in the CLI
  Quick Start (it existed in `scripts/` but was never linked).

## Corrections discovered while auditing
- **v0.1.0 is not yet tagged.** There are no git tags and
  `.release-please-manifest.json` is at `0.0.0`. release-please is configured
  with `release-as: 0.1.0`; the next merge to `main` opens the v0.1.0 Release
  PR, whose merge cuts the tag and auto-generates the CHANGELOG. The empty
  `CHANGELOG.md` is intentional and must not be hand-edited.
- **Premiumize and AllDebrid plugins are complete**, not skeletons — they
  implement `resolve`/`login`/`checkOnline` to the same standard as
  real-debrid. No work needed there.

## Deliberately deferred (need their own PR / inputs)
- Token-bucket rate limit (audit #15) — security middleware; needs ConnectInfo
  wiring + eviction + integration tests. Own PR, as the audit recommended.
- Plugin marketplace UI — needs browser verification.
- OpenAPI codegen (#40) — architectural.
- Tauri updater activation — gated on signing keys (see release-todo.md).

## Test plan
- [x] `cargo metadata --no-deps` parses the workspace cleanly.
- [ ] CI green on this branch.
