### PR TITLE
App review: cancel-during-retry fix + safe optimizations

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -531,8 +531,10 @@ async fn direct_download(
         speed_bytes_per_sec: 0,
     });
 
-    let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
-    let _ = cancel_tx; // Keep alive — drop only on ctrl-c
+    // The CLI direct path has no interactive cancel handler. Dropping the
+    // sender leaves `wait_for_cancel` pending for the whole download, so it
+    // never spuriously cancels.
+    let (_, cancel_rx) = tokio::sync::watch::channel(false);
 
     // Use ProtocolBackend trait dispatch — same as server
     let bw = BandwidthLimiter::new(config.bandwidth);

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -531,7 +531,7 @@ async fn direct_download(
         speed_bytes_per_sec: 0,
     });
 
-    let (cancel_tx, cancel_rx) = tokio::sync::oneshot::channel::<()>();
+    let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
     let _ = cancel_tx; // Keep alive — drop only on ctrl-c
 
     // Use ProtocolBackend trait dispatch — same as server

--- a/crates/core/src/coordinator.rs
+++ b/crates/core/src/coordinator.rs
@@ -76,7 +76,10 @@ pub enum DownloadEvent {
 
 /// Tracks an active download task.
 struct ActiveDownload {
-    cancel_tx: tokio::sync::oneshot::Sender<()>,
+    /// Cancellation signal. A `watch::<bool>` (rather than a one-shot) so the
+    /// flag survives across retry attempts — flipping it to `true` cancels a
+    /// download even while it is mid-retry.
+    cancel_tx: watch::Sender<bool>,
     progress_rx: watch::Receiver<DownloadProgress>,
 }
 
@@ -323,7 +326,7 @@ impl Coordinator {
             status: "downloading".to_string(),
         });
 
-        let (cancel_tx, cancel_rx) = tokio::sync::oneshot::channel();
+        let (cancel_tx, cancel_rx) = watch::channel(false);
         let (progress_tx, progress_rx) = watch::channel(DownloadProgress {
             bytes_downloaded: 0,
             total_bytes: None,
@@ -381,21 +384,13 @@ impl Coordinator {
             // and the UI silently froze at "0%" through every retry. We
             // clone the same sender into each attempt so every byte of
             // progress flows through the original watch.
-            let mut original_cancel_rx = Some(cancel_rx);
-
             let result = retry_with_policy(&retry_policy, |attempt| {
                 let ptx = progress_tx.clone();
 
-                // The cancel channel is still a oneshot: cancel() consumes
-                // the sender so a second cancel is a no-op (intentional).
-                // After the first attempt that consumed `cancel_rx` the
-                // download cannot be cancelled mid-retry; that branch is
-                // tracked by audit #13 follow-up. Use a placeholder rx so
-                // retries don't block on cancel forever.
-                let crx = original_cancel_rx.take().unwrap_or_else(|| {
-                    let (_tx, rx) = tokio::sync::oneshot::channel();
-                    rx
-                });
+                // The cancel signal is a `watch::<bool>` shared across every
+                // attempt: each retry gets its own receiver clone, so flipping
+                // the flag to `true` cancels the download even mid-retry.
+                let crx = cancel_rx.clone();
 
                 let storage = &storage;
                 let download_id = &download_id;
@@ -448,7 +443,7 @@ impl Coordinator {
 
                     match result {
                         Ok(value) => RetryOutcome::Success(value),
-                        Err(e) if e.to_string().contains("cancelled") => RetryOutcome::Abort(e),
+                        Err(e @ crate::Error::Cancelled) => RetryOutcome::Abort(e),
                         Err(e) => {
                             warn!("Download attempt failed: {download_id} — {e}");
                             RetryOutcome::Retry(e)
@@ -511,7 +506,7 @@ impl Coordinator {
     pub async fn pause(&self, id: &str) -> Result<(), crate::Error> {
         let mut active = self.active.lock().await;
         if let Some(dl) = active.remove(id) {
-            let _ = dl.cancel_tx.send(());
+            dl.cancel_tx.send_replace(true);
         }
         self.storage
             .update_download_status(id, QueueStatus::Paused)
@@ -536,7 +531,7 @@ impl Coordinator {
     pub async fn cancel(&self, id: &str) -> Result<(), crate::Error> {
         let mut active = self.active.lock().await;
         if let Some(dl) = active.remove(id) {
-            let _ = dl.cancel_tx.send(());
+            dl.cancel_tx.send_replace(true);
         }
         drop(active);
         self.storage.delete_download(id).await?;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -121,6 +121,11 @@ pub enum Error {
     #[error("URL already in queue (existing download id: {0})")]
     DuplicateUrl(String),
 
+    /// The download was cancelled by the user. Recognised explicitly so the
+    /// retry loop aborts instead of treating it as a transient failure.
+    #[error("Download cancelled")]
+    Cancelled,
+
     #[error("{0}")]
     Other(String),
 }

--- a/crates/core/src/protocol/dash.rs
+++ b/crates/core/src/protocol/dash.rs
@@ -347,7 +347,7 @@ impl super::ProtocolBackend for DashDownloader {
         &self,
         job: &super::DownloadJob,
         progress_tx: watch::Sender<DownloadProgress>,
-        cancel_rx: tokio::sync::oneshot::Receiver<()>,
+        mut cancel_rx: watch::Receiver<bool>,
     ) -> Result<(u64, std::path::PathBuf), crate::Error> {
         let fname = job.filename.clone().unwrap_or_else(|| {
             job.url
@@ -362,7 +362,7 @@ impl super::ProtocolBackend for DashDownloader {
 
         tokio::select! {
             result = self.download(&job.url, &dest, progress_tx) => result.map(|bytes| (bytes, dest)),
-            _ = cancel_rx => Err(crate::Error::Other("Download cancelled".into())),
+            _ = super::wait_for_cancel(&mut cancel_rx) => Err(crate::Error::Cancelled),
         }
     }
 }

--- a/crates/core/src/protocol/hls.rs
+++ b/crates/core/src/protocol/hls.rs
@@ -213,7 +213,7 @@ impl super::ProtocolBackend for HlsDownloader {
         &self,
         job: &super::DownloadJob,
         progress_tx: watch::Sender<DownloadProgress>,
-        cancel_rx: tokio::sync::oneshot::Receiver<()>,
+        mut cancel_rx: watch::Receiver<bool>,
     ) -> Result<(u64, std::path::PathBuf), crate::Error> {
         let fname = job.filename.clone().unwrap_or_else(|| {
             job.url
@@ -229,7 +229,7 @@ impl super::ProtocolBackend for HlsDownloader {
 
         tokio::select! {
             result = self.download(&job.url, &dest, progress_tx) => result.map(|bytes| (bytes, dest)),
-            _ = cancel_rx => Err(crate::Error::Other("Download cancelled".into())),
+            _ = super::wait_for_cancel(&mut cancel_rx) => Err(crate::Error::Cancelled),
         }
     }
 }

--- a/crates/core/src/protocol/http.rs
+++ b/crates/core/src/protocol/http.rs
@@ -119,7 +119,7 @@ impl HttpDownloader {
             let now = tokio::time::Instant::now();
             let elapsed = now.duration_since(last_update);
             if elapsed.as_millis() >= 500 {
-                let speed = (speed_bytes as f64 / elapsed.as_secs_f64()) as u64;
+                let speed = bytes_per_sec(speed_bytes, elapsed);
                 let _ = progress_tx.send(DownloadProgress {
                     bytes_downloaded: downloaded,
                     total_bytes: total,
@@ -204,7 +204,7 @@ impl HttpDownloader {
                     let now = tokio::time::Instant::now();
                     let elapsed = now.duration_since(last_time);
                     let delta = total_downloaded.saturating_sub(last_total);
-                    let speed = (delta as f64 / elapsed.as_secs_f64()) as u64;
+                    let speed = bytes_per_sec(delta, elapsed);
 
                     let _ = tx.send(DownloadProgress {
                         bytes_downloaded: total_downloaded,
@@ -345,7 +345,7 @@ impl HttpDownloader {
             let now = tokio::time::Instant::now();
             let elapsed = now.duration_since(last_update);
             if elapsed.as_millis() >= 500 {
-                let speed = (speed_bytes as f64 / elapsed.as_secs_f64()) as u64;
+                let speed = bytes_per_sec(speed_bytes, elapsed);
                 let _ = progress_tx.send(DownloadProgress {
                     bytes_downloaded: downloaded,
                     total_bytes: total,
@@ -426,6 +426,18 @@ async fn download_chunk(
     Ok(())
 }
 
+/// Compute a transfer rate in bytes/sec, guarding against a zero (or
+/// otherwise degenerate) elapsed interval which would yield `inf`/`NaN` and
+/// cast to a nonsensical `u64`.
+fn bytes_per_sec(bytes: u64, elapsed: std::time::Duration) -> u64 {
+    let secs = elapsed.as_secs_f64();
+    if secs > 0.0 {
+        (bytes as f64 / secs) as u64
+    } else {
+        0
+    }
+}
+
 /// Parse filename from Content-Disposition header.
 fn parse_content_disposition_filename(header: &str) -> Option<String> {
     // Try filename*= (RFC 5987)
@@ -470,7 +482,7 @@ impl super::ProtocolBackend for HttpDownloader {
         &self,
         job: &super::DownloadJob,
         progress_tx: watch::Sender<DownloadProgress>,
-        cancel_rx: tokio::sync::oneshot::Receiver<()>,
+        mut cancel_rx: watch::Receiver<bool>,
     ) -> Result<(u64, std::path::PathBuf), crate::Error> {
         let head = self.head(&job.url).await?;
 
@@ -504,12 +516,12 @@ impl super::ProtocolBackend for HttpDownloader {
 
             tokio::select! {
                 result = self.download_chunked(&job.url, &dest, &chunk_dir, total, chunks, progress_tx) => result.map(|bytes| (bytes, dest)),
-                _ = cancel_rx => Err(crate::Error::Other("Download cancelled".into())),
+                _ = super::wait_for_cancel(&mut cancel_rx) => Err(crate::Error::Cancelled),
             }
         } else {
             tokio::select! {
                 result = self.download_single(&job.url, &dest, progress_tx) => result.map(|bytes| (bytes, dest)),
-                _ = cancel_rx => Err(crate::Error::Other("Download cancelled".into())),
+                _ = super::wait_for_cancel(&mut cancel_rx) => Err(crate::Error::Cancelled),
             }
         }
     }
@@ -518,6 +530,17 @@ impl super::ProtocolBackend for HttpDownloader {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn bytes_per_sec_guards_against_zero_elapsed() {
+        // A zero interval must not yield inf/NaN cast to a bogus u64.
+        assert_eq!(bytes_per_sec(1000, std::time::Duration::ZERO), 0);
+        // Normal case: 1000 bytes over 0.5s = 2000 B/s.
+        assert_eq!(
+            bytes_per_sec(1000, std::time::Duration::from_millis(500)),
+            2000
+        );
+    }
 
     #[tokio::test]
     async fn fsync_file_persists_buffered_writes() {

--- a/crates/core/src/protocol/mod.rs
+++ b/crates/core/src/protocol/mod.rs
@@ -37,6 +37,25 @@ pub struct DownloadJob {
     pub user_agent: String,
 }
 
+/// Resolve once the cancellation flag flips to `true`.
+///
+/// Cancellation is carried over a `watch::<bool>` channel (instead of a
+/// one-shot) so the same signal survives across every retry attempt — a
+/// download stuck in the retry loop must still be cancellable. If the sender
+/// is dropped (download finished, nobody can cancel any more) this future
+/// stays pending forever so a `select!` never spuriously resolves it.
+pub async fn wait_for_cancel(rx: &mut watch::Receiver<bool>) {
+    if *rx.borrow() {
+        return;
+    }
+    while rx.changed().await.is_ok() {
+        if *rx.borrow() {
+            return;
+        }
+    }
+    std::future::pending::<()>().await;
+}
+
 /// Unified trait for all protocol backends.
 #[async_trait::async_trait]
 pub trait ProtocolBackend: Send + Sync {
@@ -48,7 +67,7 @@ pub trait ProtocolBackend: Send + Sync {
         &self,
         job: &DownloadJob,
         progress_tx: watch::Sender<DownloadProgress>,
-        cancel_rx: tokio::sync::oneshot::Receiver<()>,
+        cancel_rx: watch::Receiver<bool>,
     ) -> Result<(u64, PathBuf), crate::Error>;
 }
 
@@ -71,4 +90,58 @@ pub struct ResolvedDownload {
 #[async_trait::async_trait]
 pub trait UrlResolver: Send + Sync {
     async fn resolve(&self, url: &str) -> Option<ResolvedDownload>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn wait_for_cancel_resolves_when_flag_already_true() {
+        let (tx, mut rx) = watch::channel(false);
+        tx.send_replace(true);
+        // Already cancelled: must resolve immediately, not hang.
+        tokio::time::timeout(std::time::Duration::from_secs(1), wait_for_cancel(&mut rx))
+            .await
+            .expect("should resolve immediately when flag is already true");
+    }
+
+    #[tokio::test]
+    async fn wait_for_cancel_resolves_when_flag_flips() {
+        let (tx, mut rx) = watch::channel(false);
+        let waiter = tokio::spawn(async move { wait_for_cancel(&mut rx).await });
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+        tx.send_replace(true);
+        tokio::time::timeout(std::time::Duration::from_secs(1), waiter)
+            .await
+            .expect("should resolve once flag flips")
+            .expect("task should not panic");
+    }
+
+    #[tokio::test]
+    async fn wait_for_cancel_survives_across_cloned_receivers() {
+        // Each retry attempt clones a fresh receiver from the same sender;
+        // a single cancel must be observable by a receiver cloned afterwards.
+        let (tx, rx) = watch::channel(false);
+        tx.send_replace(true);
+        let mut attempt_rx = rx.clone();
+        tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            wait_for_cancel(&mut attempt_rx),
+        )
+        .await
+        .expect("cloned receiver must observe the cancellation");
+    }
+
+    #[tokio::test]
+    async fn wait_for_cancel_stays_pending_without_cancel() {
+        let (_tx, mut rx) = watch::channel(false);
+        // No cancel sent: the future must not resolve.
+        let res = tokio::time::timeout(
+            std::time::Duration::from_millis(50),
+            wait_for_cancel(&mut rx),
+        )
+        .await;
+        assert!(res.is_err(), "should still be pending when not cancelled");
+    }
 }

--- a/crates/plugin-runtime/src/engine.rs
+++ b/crates/plugin-runtime/src/engine.rs
@@ -193,7 +193,11 @@ impl PluginContext {
     /// Call the async `resolve(url)` function and return the result as JSON string.
     /// The JS function returns a Promise which we resolve synchronously via the event loop.
     pub fn call_resolve(&self, url: &str, timeout: Duration) -> Result<String, crate::Error> {
-        let url = url.to_string();
+        // Serialise the URL as a JSON string literal — also a valid JS string
+        // literal — so quotes/backslashes/control chars are escaped correctly
+        // instead of relying on hand-rolled string escaping.
+        let url_lit = serde_json::to_string(url)
+            .map_err(|e| crate::Error::Execution(format!("failed to encode url: {e}")))?;
 
         // We wrap the resolve call in a script that catches the Promise result
         let script = format!(
@@ -203,7 +207,7 @@ impl PluginContext {
                 var __resolve_error = null;
                 var __resolve_done = false;
 
-                var p = __plugin_exports.resolve("{url}");
+                var p = __plugin_exports.resolve({url_lit});
                 if (p && typeof p.then === 'function') {{
                     p.then(function(r) {{
                         __resolve_result = JSON.stringify(r);
@@ -221,7 +225,6 @@ impl PluginContext {
                 return __resolve_done ? (__resolve_error ? "ERROR:" + __resolve_error : __resolve_result) : "PENDING";
             }})()
             "#,
-            url = url.replace('\\', "\\\\").replace('"', "\\\""),
         );
 
         self.with_deadline(timeout, |ctx, deadline_ms| {
@@ -288,14 +291,18 @@ impl PluginContext {
         context_json: &str,
         timeout: Duration,
     ) -> Result<String, crate::Error> {
-        let escaped = context_json.replace('\\', "\\\\").replace('\'', "\\'");
+        // Encode the JSON document as a JS string literal (valid JS, correctly
+        // escaped) and parse it back inside the VM, instead of hand-rolling
+        // quote escaping into a single-quoted literal.
+        let ctx_lit = serde_json::to_string(context_json)
+            .map_err(|e| crate::Error::Execution(format!("failed to encode context: {e}")))?;
         let script = format!(
             r#"
             (function() {{
                 if (typeof __plugin_exports.postProcess !== 'function') {{
                     return JSON.stringify({{ success: true, message: "no postProcess hook" }});
                 }}
-                var ctx = JSON.parse('{escaped}');
+                var ctx = JSON.parse({ctx_lit});
                 var result = __plugin_exports.postProcess(ctx);
                 return JSON.stringify(result);
             }})()

--- a/crates/plugin-runtime/src/host_api.rs
+++ b/crates/plugin-runtime/src/host_api.rs
@@ -68,16 +68,46 @@ fn enforce_input_limit(field: &str, len: usize, max: usize) -> Result<(), String
     }
 }
 
+/// Upper bound on cached compiled regexes. Plugins typically use a small,
+/// fixed set of patterns; when this is exceeded the cache is cleared wholesale
+/// (cheap and avoids unbounded growth from pathological pattern churn).
+const REGEX_CACHE_MAX_ENTRIES: usize = 256;
+
+/// Process-wide cache of compiled regexes keyed by pattern source. Compilation
+/// is deterministic from the pattern, and `regex::Regex` is internally
+/// reference-counted so clones are cheap — this turns repeated `regexMatch`
+/// calls in plugin hot loops from "recompile every call" into a hashmap lookup.
+static REGEX_CACHE: std::sync::LazyLock<std::sync::Mutex<HashMap<String, regex::Regex>>> =
+    std::sync::LazyLock::new(|| std::sync::Mutex::new(HashMap::new()));
+
 /// Compile a regex with the global plugin-side size limits applied. Returns
 /// the compiled `Regex` or a string error suitable for surfacing to the JS
-/// caller.
+/// caller. Results are cached by pattern (see [`REGEX_CACHE`]).
 fn compile_plugin_regex(pattern: &str) -> Result<regex::Regex, String> {
     enforce_input_limit("regex pattern", pattern.len(), MAX_REGEX_PATTERN_BYTES)?;
-    regex::RegexBuilder::new(pattern)
+
+    {
+        let cache = REGEX_CACHE.lock().unwrap_or_else(|e| e.into_inner());
+        if let Some(re) = cache.get(pattern) {
+            return Ok(re.clone());
+        }
+    }
+
+    let re = regex::RegexBuilder::new(pattern)
         .size_limit(REGEX_COMPILE_SIZE_LIMIT)
         .dfa_size_limit(REGEX_DFA_SIZE_LIMIT)
         .build()
-        .map_err(|e| format!("invalid regex: {e}"))
+        .map_err(|e| format!("invalid regex: {e}"))?;
+
+    {
+        let mut cache = REGEX_CACHE.lock().unwrap_or_else(|e| e.into_inner());
+        if cache.len() >= REGEX_CACHE_MAX_ENTRIES {
+            cache.clear();
+        }
+        cache.insert(pattern.to_string(), re.clone());
+    }
+
+    Ok(re)
 }
 
 /// Shared state for the Host API, passed into every plugin call.
@@ -1826,15 +1856,25 @@ pub fn register_host_api(
 fn base64_decode_bytes(input: &str) -> Result<Vec<u8>, String> {
     enforce_input_limit("base64 input", input.len(), MAX_BASE64_INPUT_BYTES)?;
     let alphabet = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-    let mut table = [0u8; 256];
+    // 0xFF marks "not a base64 symbol" so we can reject invalid input instead
+    // of silently mapping it to 'A' (index 0) and producing garbage bytes.
+    const INVALID: u8 = 0xFF;
+    let mut table = [INVALID; 256];
     for (i, &c) in alphabet.iter().enumerate() {
         table[c as usize] = i as u8;
     }
 
+    // Strip padding and the usual line-wrapping whitespace; everything else
+    // must be a real alphabet symbol.
     let filtered: Vec<u8> = input
         .bytes()
-        .filter(|&c| c != b'=' && c != b'\n' && c != b'\r' && c != b' ')
+        .filter(|&c| c != b'=' && c != b'\n' && c != b'\r' && c != b' ' && c != b'\t')
         .collect();
+    for &c in &filtered {
+        if table[c as usize] == INVALID {
+            return Err("invalid base64 character".to_string());
+        }
+    }
     let mut buf = Vec::with_capacity(filtered.len() * 3 / 4);
 
     for chunk in filtered.chunks(4) {
@@ -2017,6 +2057,40 @@ mod tests {
         let encoded = api.base64_encode("Hello, World!");
         let decoded = api.base64_decode(&encoded).unwrap();
         assert_eq!(decoded, "Hello, World!");
+    }
+
+    #[test]
+    fn base64_decode_rejects_invalid_characters() {
+        let api = HostApi::new(20);
+        // '*' and '#' are not in the base64 alphabet — must error instead of
+        // silently mapping to 'A' and producing garbage bytes.
+        let err = api
+            .base64_decode("SGVsbG8*#")
+            .expect_err("invalid base64 must be rejected");
+        assert!(err.contains("invalid base64 character"), "msg: {err}");
+    }
+
+    #[test]
+    fn base64_decode_tolerates_whitespace_and_padding() {
+        let api = HostApi::new(20);
+        // Standard encoders wrap lines and pad; these must still decode.
+        let encoded = api.base64_encode("The quick brown fox");
+        let wrapped = format!("{}\n {}", &encoded[..8], &encoded[8..]);
+        assert_eq!(api.base64_decode(&wrapped).unwrap(), "The quick brown fox");
+    }
+
+    #[test]
+    fn regex_cache_returns_consistent_results() {
+        let api = HostApi::new(20);
+        // Same pattern used repeatedly must keep matching correctly whether or
+        // not it was served from the compile cache.
+        for _ in 0..3 {
+            assert_eq!(
+                api.regex_match(r"\d+", "abc123def"),
+                Some("123".to_string())
+            );
+        }
+        assert!(api.regex_test(r"^foo", "foobar"));
     }
 
     #[tokio::test]

--- a/docs/app-review-2026-05.md
+++ b/docs/app-review-2026-05.md
@@ -1,0 +1,103 @@
+# App Review — May 2026
+
+Scope: a focused correctness + performance pass across `core`,
+`plugin-runtime`/`extractors`, `server`, and `web-ui`. A broad automated sweep
+produced ~40 candidate findings; each was validated against the actual code
+before any change. This document records what was fixed, what was rejected as a
+false positive (so it is not "re-discovered"), and what is deliberately
+deferred.
+
+## Fixed in this change
+
+| # | Area | Type | Summary |
+|---|------|------|---------|
+| 1 | `core` | **Bug** | Downloads could not be cancelled while stuck in the retry loop. |
+| 2 | `core` | Robustness | Speed calculation could divide by a zero interval (→ `inf`). |
+| 3 | `plugin-runtime` | Perf | Plugin regex helpers recompiled the pattern on every call. |
+| 4 | `plugin-runtime` | Correctness | base64 decoder silently accepted invalid characters. |
+| 5 | `plugin-runtime` | Correctness | Plugin-VM scripts built via hand-rolled string escaping. |
+
+### 1. Cancel during retry (main fix)
+
+`Coordinator` carried cancellation over a `oneshot` channel. The receiver was
+consumed by the first download attempt; every subsequent retry got a throwaway
+receiver that never fired, so a download repeatedly failing-and-retrying could
+not be cancelled or paused (the original code even acknowledged this as an
+"audit #13 follow-up"). Cancel detection also relied on a brittle
+`e.to_string().contains("cancelled")` substring match.
+
+Fix:
+- New `Error::Cancelled` variant; the retry loop matches it explicitly and
+  aborts instead of treating it as a transient failure.
+- `ProtocolBackend::download` now takes a `tokio::sync::watch::Receiver<bool>`
+  (no new dependency — `watch` was already used) instead of a one-shot. A
+  shared `wait_for_cancel` helper resolves when the flag flips and stays pending
+  if the sender is dropped. Each retry clones a fresh receiver from the same
+  sender, so a single `cancel`/`pause` is observed across all attempts.
+- HTTP / HLS / DASH backends and the CLI direct-download path updated
+  accordingly.
+
+### 2. Speed division guard
+
+`bytes / elapsed.as_secs_f64()` is now routed through a `bytes_per_sec` helper
+that returns `0` for a zero/degenerate interval, preventing an `inf`/`NaN` cast
+to a nonsensical `u64`.
+
+### 3. Regex compile cache
+
+`compile_plugin_regex` is the single chokepoint for all `regexMatch/MatchAll/
+Replace/Test/Split` host functions. It now caches compiled `regex::Regex`
+values by pattern in a bounded process-wide map (cap 256, cleared wholesale on
+overflow). `Regex` is internally reference-counted, so cache hits are cheap and
+turn hot-loop regex usage from "recompile every call" into a map lookup. Input
+size limits are still enforced before the lookup.
+
+### 4. base64 decoder hardening
+
+`base64_decode_bytes` built a lookup table that mapped every non-alphabet byte
+to `0` (= `A`), so malformed input decoded to silent garbage. It now uses a
+`0xFF` sentinel and returns `invalid base64 character` for any byte that is not
+an alphabet symbol or stripped whitespace/padding (newlines, CR, space, tab,
+`=`).
+
+### 5. JS interpolation via `serde_json`
+
+`call_resolve` and `call_post_process` built the eval'd script by hand-escaping
+quotes/backslashes. They now serialise the URL / context with
+`serde_json::to_string`, which yields a correctly-escaped JS string literal and
+removes a class of escaping edge cases.
+
+## Rejected (validated false positives)
+
+These were reported by the automated sweep but do not hold up against the code:
+
+- **Chunk-index out-of-bounds panic** (`http.rs`): `chunk_progress` is sized
+  exactly `num_chunks` and indexed by `0..num_chunks` — always in bounds.
+- **`content_length.unwrap()` race** (`http.rs`): `head` is an immutable local;
+  no concurrent mutation is possible between the `is_some_and` check and the
+  `unwrap`.
+- **Chunk-size off-by-one** (`http.rs`): the last chunk is special-cased to
+  `total_size - 1`, so integer division leaves no gap.
+- **NZB watch-folder path traversal** (`background.rs`): the watch directory is
+  an admin-configured setting; choosing its location is by design, not an
+  escalation.
+- **Web-UI speed field mismatch**: `App.svelte` already maps
+  `progress.speed_bytes_per_sec` onto the store's `speed` field.
+- **player.js cache memory leak** (`n_challenge.rs`): the cache already enforces
+  both a 12 h TTL and an 8-entry LRU cap (oldest evicted on insert).
+
+## Deferred recommendations
+
+Not addressed here to keep the change low-risk; worth a dedicated follow-up:
+
+- **Storage off the async executor**: `Storage` holds a synchronous
+  `rusqlite::Connection` behind an async mutex. Local SQLite queries are fast,
+  but moving them onto `spawn_blocking` (or an async SQLite layer) would remove
+  any chance of stalling the runtime under contention.
+- **`Arc<Config>` instead of per-download clones**: `Coordinator` clones the
+  full `Config` for each started download. Sharing an `Arc<Config>` (swapped via
+  `RwLock`) would cut allocation churn under high concurrency.
+- **SSRF DNS pinning**: plugin HTTP and webhook dispatch validate the resolved
+  IP class but re-resolve at request time, leaving a theoretical DNS-rebinding
+  window. Pinning the resolved IP between check and connect would close it. This
+  is a deliberate, documented trade-off for now.


### PR DESCRIPTION
## Context

A focused correctness + performance pass across `core`, `plugin-runtime`, and the CLI. A broad automated sweep produced ~40 candidate findings; each was **validated against the actual code** before any change. Most of the "critical" auto-findings turned out to be false positives (documented below). This PR implements only the validated, high-confidence items.

Full write-up: `docs/app-review-2026-05.md`.

## Changes

### 🐞 Bug: downloads couldn't be cancelled during retry (main fix)
Cancellation was carried over a `oneshot` channel consumed by the first attempt; every retry then got a throwaway receiver that never fired, so a download stuck in the retry loop could not be cancelled or paused (the original code acknowledged this as an "audit #13 follow-up"). Cancel detection also used a brittle `to_string().contains("cancelled")` match.

- New `Error::Cancelled` variant; the retry loop matches it explicitly and aborts instead of retrying.
- `ProtocolBackend::download` now takes a `watch::Receiver<bool>` (no new dependency — `watch` was already in use) shared across attempts via a `wait_for_cancel` helper. Each retry clones a fresh receiver from the same sender, so one `cancel`/`pause` is observed across all attempts.
- HTTP / HLS / DASH backends and the CLI direct-download path updated.

### 🛡️ Robustness: speed division guard
Transfer-rate math is routed through a `bytes_per_sec` helper that returns `0` for a zero/degenerate interval (previously could produce `inf`/`NaN` cast to a bogus `u64`).

### ⚡ Perf: regex compile cache
`compile_plugin_regex` (the single chokepoint for all regex host functions) now caches compiled `Regex` by pattern, bounded at 256 entries. Plugins calling `regexMatch`/etc. in hot loops no longer recompile every call. Size limits still enforced before lookup.

### ✅ Correctness: base64 + JS interop
- base64 decoder rejects non-alphabet characters via a `0xFF` sentinel instead of silently mapping them to `A` and producing garbage.
- `call_resolve` / `call_post_process` build the eval'd script via `serde_json::to_string` instead of hand-rolled quote escaping.

## Rejected false positives (validated)
Chunk-index panic, `content_length.unwrap()` race, chunk-size off-by-one, NZB watch-folder "path traversal" (admin-configured by design), web-UI speed field mismatch, and player.js cache "leak" (already TTL + LRU capped). Details in the doc.

## Deferred (documented, out of scope)
Storage off the async executor, `Arc<Config>` instead of per-download clones, SSRF DNS pinning.

## Verification
- `cargo test -p amigo-core -p amigo-plugin-runtime` — all pass, incl. new regression tests (`wait_for_cancel` semantics, `bytes_per_sec` zero-guard, base64 invalid/whitespace, regex-cache consistency).
- `cargo clippy -p amigo-core -p amigo-plugin-runtime -p amigo-cli --all-targets -- -D warnings` — clean.
- `cargo build --workspace` — clean (server crate verified once `web-ui/dist` was present).

_Note: the web-ui couldn't be built in this environment (`workspace:*` dep needs pnpm); no frontend code was changed._


---
_Generated by [Claude Code](https://claude.ai/code/session_01QhJ3kqvGkPpY61jXg5JVsf)_