### PR TITLE
perf: whole-repo performance optimization (build, core, extractors, plugins, web-ui)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,6 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "tokio",
  "tracing",
  "url",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,21 @@ authors = ["amigo-labs"]
 description = "Fast, modular download manager in Rust — HTTP, Usenet, HLS/DASH, with a TypeScript plugin system and a responsive Web UI."
 
 [workspace.dependencies]
-# Async runtime
-tokio = { version = "1", features = ["full"] }
+# Async runtime. Feature set is the union of what the member crates actually
+# use (rt-multi-thread is mandatory: plugin-runtime relies on block_in_place,
+# which panics on a current-thread runtime). This drops `process` and `io-std`
+# from the old `full`. Test builds restore `full` via dev-dependencies.
+tokio = { version = "1", features = [
+    "rt",
+    "rt-multi-thread",
+    "macros",
+    "sync",
+    "fs",
+    "io-util",
+    "time",
+    "net",
+    "signal",
+] }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,16 @@ default-members = [
 
 # Release profile tuned for runtime speed and small binaries.
 # `[profile.*]` is only honored in the workspace root and applies to all members.
-# `panic = "abort"` is added in a later, independently revertible commit.
+# `panic = "abort"` is safe here: the codebase has no catch_unwind / std::panic
+# recovery and rquickjs surfaces JS errors as Err, not via unwinding. It only
+# affects the release profile, so `cargo test` (test profile) is unaffected —
+# but do not run `cargo test --release`.
 [profile.release]
 opt-level = 3
 lto = "fat"
 codegen-units = 1
 strip = "symbols"
+panic = "abort"
 
 [workspace.package]
 version = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,15 @@ default-members = [
     "crates/cli",
 ]
 
+# Release profile tuned for runtime speed and small binaries.
+# `[profile.*]` is only honored in the workspace root and applies to all members.
+# `panic = "abort"` is added in a later, independently revertible commit.
+[profile.release]
+opt-level = 3
+lto = "fat"
+codegen-units = 1
+strip = "symbols"
+
 [workspace.package]
 version = "0.1.0"
 edition = "2024"

--- a/crates/core/src/coordinator.rs
+++ b/crates/core/src/coordinator.rs
@@ -198,14 +198,11 @@ impl Coordinator {
         category: Option<String>,
         priority: i32,
     ) -> Result<String, crate::Error> {
-        // Duplicate detection: check if same URL is already queued/downloading
-        let existing = self.storage.list_downloads().await?;
-        if let Some(dup) = existing.iter().find(|d| {
-            d.url == url
-                && (d.status == "queued" || d.status == "downloading" || d.status == "paused")
-        }) {
-            info!("Duplicate download skipped: {} (existing: {})", url, dup.id);
-            return Ok(dup.id.clone());
+        // Duplicate detection: check if same URL is already queued/downloading.
+        // Indexed point lookup rather than scanning every download.
+        if let Some(dup_id) = self.storage.find_active_download_by_url(url).await? {
+            info!("Duplicate download skipped: {} (existing: {})", url, dup_id);
+            return Ok(dup_id);
         }
 
         let id = Uuid::new_v4().to_string();

--- a/crates/core/src/protocol/dash.rs
+++ b/crates/core/src/protocol/dash.rs
@@ -6,7 +6,7 @@
 use std::path::Path;
 
 use tokio::sync::watch;
-use tracing::{debug, info, warn};
+use tracing::info;
 
 use super::http::DownloadProgress;
 
@@ -33,6 +33,7 @@ impl DashDownloader {
         &self,
         mpd_url: &str,
         dest: &Path,
+        seg_dir: &Path,
         progress_tx: watch::Sender<DownloadProgress>,
     ) -> Result<u64, crate::Error> {
         info!("Downloading DASH stream: {mpd_url}");
@@ -105,75 +106,17 @@ impl DashDownloader {
             self.concurrent_segments
         );
 
-        // Download all segments
-        let mut all_data: Vec<(usize, Vec<u8>)> = Vec::with_capacity(segment_urls.len());
-        let mut total_bytes: u64 = 0;
-
-        for chunk in segment_urls.chunks(self.concurrent_segments) {
-            let mut handles = Vec::new();
-
-            for (offset, url) in chunk.iter().enumerate() {
-                let client = self.client.clone();
-                let url = url.clone();
-                let idx = all_data.len() + offset;
-
-                handles.push(tokio::spawn(async move {
-                    let resp = client.get(&url).send().await?;
-                    let bytes = resp.bytes().await?;
-                    Ok::<(usize, Vec<u8>), reqwest::Error>((idx, bytes.to_vec()))
-                }));
-            }
-
-            for handle in handles {
-                match handle.await {
-                    Ok(Ok((idx, data))) => {
-                        total_bytes += data.len() as u64;
-                        all_data.push((idx, data));
-
-                        let _ = progress_tx.send(DownloadProgress {
-                            bytes_downloaded: total_bytes,
-                            total_bytes: None,
-                            speed_bytes_per_sec: 0,
-                        });
-                    }
-                    Ok(Err(e)) => {
-                        warn!("DASH segment download failed: {e}");
-                        return Err(crate::Error::Http(e));
-                    }
-                    Err(e) => {
-                        warn!("DASH segment task failed: {e}");
-                        return Err(crate::Error::Other(e.to_string()));
-                    }
-                }
-            }
-
-            debug!(
-                "DASH: downloaded {}/{} segments",
-                all_data.len(),
-                segment_urls.len()
-            );
-        }
-
-        // Sort and reassemble
-        all_data.sort_by_key(|(idx, _)| *idx);
-
-        if let Some(parent) = dest.parent() {
-            tokio::fs::create_dir_all(parent).await?;
-        }
-
-        let mut output = tokio::fs::File::create(dest).await?;
-        for (_, data) in &all_data {
-            tokio::io::AsyncWriteExt::write_all(&mut output, data).await?;
-        }
+        let total_bytes = super::http::download_segments_streamed(
+            &self.client,
+            &segment_urls,
+            dest,
+            seg_dir,
+            self.concurrent_segments,
+            progress_tx,
+        )
+        .await?;
 
         info!("DASH: wrote {} bytes to {}", total_bytes, dest.display());
-
-        let _ = progress_tx.send(DownloadProgress {
-            bytes_downloaded: total_bytes,
-            total_bytes: Some(total_bytes),
-            speed_bytes_per_sec: 0,
-        });
-
         Ok(total_bytes)
     }
 }
@@ -359,9 +302,11 @@ impl super::ProtocolBackend for DashDownloader {
         });
         let dest = job.download_dir.join(&fname);
         tokio::fs::create_dir_all(&job.download_dir).await?;
+        // Per-download scratch space for the segment temp files.
+        let seg_dir = job.temp_dir.join(format!("dash-{}", job.download_id));
 
         tokio::select! {
-            result = self.download(&job.url, &dest, progress_tx) => result.map(|bytes| (bytes, dest)),
+            result = self.download(&job.url, &dest, &seg_dir, progress_tx) => result.map(|bytes| (bytes, dest)),
             _ = super::wait_for_cancel(&mut cancel_rx) => Err(crate::Error::Cancelled),
         }
     }

--- a/crates/core/src/protocol/hls.rs
+++ b/crates/core/src/protocol/hls.rs
@@ -6,7 +6,7 @@
 use std::path::Path;
 
 use tokio::sync::watch;
-use tracing::{debug, info, warn};
+use tracing::info;
 
 use super::http::DownloadProgress;
 
@@ -33,6 +33,7 @@ impl HlsDownloader {
         &self,
         manifest_url: &str,
         dest: &Path,
+        seg_dir: &Path,
         progress_tx: watch::Sender<DownloadProgress>,
     ) -> Result<u64, crate::Error> {
         info!("Downloading HLS stream: {manifest_url}");
@@ -69,7 +70,7 @@ impl HlsDownloader {
 
                 match media_parsed {
                     m3u8_rs::Playlist::MediaPlaylist(pl) => {
-                        self.download_segments(&variant_url, &pl, dest, progress_tx)
+                        self.download_segments(&variant_url, &pl, dest, seg_dir, progress_tx)
                             .await
                     }
                     _ => Err(crate::Error::Other(
@@ -78,7 +79,7 @@ impl HlsDownloader {
                 }
             }
             m3u8_rs::Playlist::MediaPlaylist(media) => {
-                self.download_segments(manifest_url, &media, dest, progress_tx)
+                self.download_segments(manifest_url, &media, dest, seg_dir, progress_tx)
                     .await
             }
         }
@@ -90,6 +91,7 @@ impl HlsDownloader {
         playlist_url: &str,
         playlist: &m3u8_rs::MediaPlaylist,
         dest: &Path,
+        seg_dir: &Path,
         progress_tx: watch::Sender<DownloadProgress>,
     ) -> Result<u64, crate::Error> {
         let segment_urls: Vec<String> = playlist
@@ -98,81 +100,23 @@ impl HlsDownloader {
             .map(|seg| resolve_url(playlist_url, &seg.uri))
             .collect();
 
-        let total_segments = segment_urls.len();
         info!(
-            "HLS: downloading {total_segments} segments ({} concurrent)",
+            "HLS: downloading {} segments ({} concurrent)",
+            segment_urls.len(),
             self.concurrent_segments
         );
 
-        // Download segments in parallel batches
-        let mut all_data: Vec<(usize, Vec<u8>)> = Vec::with_capacity(total_segments);
-        let mut total_bytes: u64 = 0;
-
-        for chunk in segment_urls.chunks(self.concurrent_segments) {
-            let mut handles = Vec::new();
-
-            for (offset, url) in chunk.iter().enumerate() {
-                let client = self.client.clone();
-                let url = url.clone();
-                let idx = all_data.len() + offset;
-
-                handles.push(tokio::spawn(async move {
-                    let resp = client.get(&url).send().await?;
-                    let bytes = resp.bytes().await?;
-                    Ok::<(usize, Vec<u8>), reqwest::Error>((idx, bytes.to_vec()))
-                }));
-            }
-
-            for handle in handles {
-                match handle.await {
-                    Ok(Ok((idx, data))) => {
-                        total_bytes += data.len() as u64;
-                        all_data.push((idx, data));
-
-                        let _ = progress_tx.send(DownloadProgress {
-                            bytes_downloaded: total_bytes,
-                            total_bytes: None,
-                            speed_bytes_per_sec: 0,
-                        });
-                    }
-                    Ok(Err(e)) => {
-                        warn!("HLS segment download failed: {e}");
-                        return Err(crate::Error::Http(e));
-                    }
-                    Err(e) => {
-                        warn!("HLS segment task failed: {e}");
-                        return Err(crate::Error::Other(e.to_string()));
-                    }
-                }
-            }
-
-            debug!(
-                "HLS: downloaded {}/{} segments",
-                all_data.len(),
-                total_segments
-            );
-        }
-
-        // Sort by index and concatenate
-        all_data.sort_by_key(|(idx, _)| *idx);
-
-        if let Some(parent) = dest.parent() {
-            tokio::fs::create_dir_all(parent).await?;
-        }
-
-        let mut output = tokio::fs::File::create(dest).await?;
-        for (_, data) in &all_data {
-            tokio::io::AsyncWriteExt::write_all(&mut output, data).await?;
-        }
+        let total_bytes = super::http::download_segments_streamed(
+            &self.client,
+            &segment_urls,
+            dest,
+            seg_dir,
+            self.concurrent_segments,
+            progress_tx,
+        )
+        .await?;
 
         info!("HLS: wrote {} bytes to {}", total_bytes, dest.display());
-
-        let _ = progress_tx.send(DownloadProgress {
-            bytes_downloaded: total_bytes,
-            total_bytes: Some(total_bytes),
-            speed_bytes_per_sec: 0,
-        });
-
         Ok(total_bytes)
     }
 }
@@ -226,10 +170,72 @@ impl super::ProtocolBackend for HlsDownloader {
         });
         let dest = job.download_dir.join(&fname);
         tokio::fs::create_dir_all(&job.download_dir).await?;
+        // Per-download scratch space for the segment temp files.
+        let seg_dir = job.temp_dir.join(format!("hls-{}", job.download_id));
 
         tokio::select! {
-            result = self.download(&job.url, &dest, progress_tx) => result.map(|bytes| (bytes, dest)),
+            result = self.download(&job.url, &dest, &seg_dir, progress_tx) => result.map(|bytes| (bytes, dest)),
             _ = super::wait_for_cancel(&mut cancel_rx) => Err(crate::Error::Cancelled),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[tokio::test]
+    async fn reassembles_segments_in_playlist_order() {
+        let server = MockServer::start().await;
+
+        // A media playlist referencing three relative segments, intentionally
+        // served so that concurrent download could finish out of order.
+        let playlist = "#EXTM3U\n\
+             #EXT-X-VERSION:3\n\
+             #EXT-X-TARGETDURATION:4\n\
+             #EXTINF:4.0,\nseg0.ts\n\
+             #EXTINF:4.0,\nseg1.ts\n\
+             #EXTINF:4.0,\nseg2.ts\n\
+             #EXT-X-ENDLIST\n";
+        Mock::given(method("GET"))
+            .and(path("/playlist.m3u8"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(playlist))
+            .mount(&server)
+            .await;
+
+        // Distinct, different-length bodies so a wrong order is unambiguous.
+        let bodies: [&[u8]; 3] = [b"AAAA", b"BB", b"CCCCCC"];
+        for (i, body) in bodies.iter().enumerate() {
+            Mock::given(method("GET"))
+                .and(path(format!("/seg{i}.ts")))
+                .respond_with(ResponseTemplate::new(200).set_body_bytes(body.to_vec()))
+                .mount(&server)
+                .await;
+        }
+
+        let tmp = tempfile::tempdir().unwrap();
+        let dest = tmp.path().join("out.ts");
+        let seg_dir = tmp.path().join("segments");
+        let (tx, _rx) = watch::channel(DownloadProgress {
+            bytes_downloaded: 0,
+            total_bytes: None,
+            speed_bytes_per_sec: 0,
+        });
+
+        let downloader = HlsDownloader::new("test-agent", 3);
+        let manifest_url = format!("{}/playlist.m3u8", server.uri());
+        let written = downloader
+            .download(&manifest_url, &dest, &seg_dir, tx)
+            .await
+            .expect("HLS download should succeed");
+
+        let expected: Vec<u8> = bodies.concat();
+        assert_eq!(written, expected.len() as u64);
+        let on_disk = tokio::fs::read(&dest).await.unwrap();
+        assert_eq!(on_disk, expected, "segments must be concatenated in order");
+        // Scratch dir must be cleaned up on success.
+        assert!(!seg_dir.exists(), "segment temp dir should be removed");
     }
 }

--- a/crates/core/src/protocol/http.rs
+++ b/crates/core/src/protocol/http.rs
@@ -12,6 +12,10 @@ use tracing::{debug, info, warn};
 
 use crate::bandwidth::BandwidthLimiter;
 
+/// Write buffer size for download/reassembly file I/O. `bytes_stream()` yields
+/// many small chunks; without buffering each one becomes its own write syscall.
+const WRITE_BUFFER_SIZE: usize = 256 * 1024;
+
 /// Flush kernel buffers and persist `file` to disk.
 ///
 /// `flush().await` only drains the user-space buffer into the kernel; if the
@@ -103,7 +107,8 @@ impl HttpDownloader {
         let resp = self.client.get(url).send().await?.error_for_status()?;
         let total = resp.content_length();
 
-        let mut file = tokio::fs::File::create(dest).await?;
+        let file = tokio::fs::File::create(dest).await?;
+        let mut writer = tokio::io::BufWriter::with_capacity(WRITE_BUFFER_SIZE, file);
         let mut stream = resp.bytes_stream();
         let mut downloaded: u64 = 0;
         let mut last_update = tokio::time::Instant::now();
@@ -112,7 +117,7 @@ impl HttpDownloader {
         while let Some(chunk) = stream.next().await {
             let chunk = chunk.map_err(crate::Error::Http)?;
             self.bandwidth.acquire(chunk.len() as u64).await;
-            file.write_all(&chunk).await?;
+            writer.write_all(&chunk).await?;
             downloaded += chunk.len() as u64;
             speed_bytes += chunk.len() as u64;
 
@@ -130,7 +135,8 @@ impl HttpDownloader {
             }
         }
 
-        fsync_file(&mut file).await?;
+        writer.flush().await?;
+        fsync_file(writer.get_mut()).await?;
 
         let _ = progress_tx.send(DownloadProgress {
             bytes_downloaded: downloaded,
@@ -234,14 +240,20 @@ impl HttpDownloader {
         let dest_tmp = dest.with_extension("part");
         debug!("Reassembling {} chunks into {:?}", num_chunks, dest_tmp);
         let reassemble_result: Result<(), crate::Error> = async {
-            let mut dest_file = tokio::fs::File::create(&dest_tmp).await?;
+            let dest_file = tokio::fs::File::create(&dest_tmp).await?;
+            let mut dest_writer = tokio::io::BufWriter::with_capacity(WRITE_BUFFER_SIZE, dest_file);
             for i in 0..num_chunks {
                 let chunk_path = temp_dir.join(format!("chunk_{i}"));
-                let chunk_data = tokio::fs::read(&chunk_path).await?;
-                dest_file.write_all(&chunk_data).await?;
+                // Stream each chunk through the buffered writer instead of
+                // loading the whole chunk into a Vec — keeps peak RAM bounded
+                // by the buffer size regardless of chunk size.
+                let mut chunk_file = tokio::fs::File::open(&chunk_path).await?;
+                tokio::io::copy(&mut chunk_file, &mut dest_writer).await?;
+                drop(chunk_file);
                 tokio::fs::remove_file(&chunk_path).await?;
             }
-            fsync_file(&mut dest_file).await?;
+            dest_writer.flush().await?;
+            fsync_file(dest_writer.get_mut()).await?;
             Ok(())
         }
         .await;
@@ -325,10 +337,11 @@ impl HttpDownloader {
             .content_length()
             .map(|remaining| remaining + existing_size);
 
-        let mut file = tokio::fs::OpenOptions::new()
+        let file = tokio::fs::OpenOptions::new()
             .append(true)
             .open(dest)
             .await?;
+        let mut writer = tokio::io::BufWriter::with_capacity(WRITE_BUFFER_SIZE, file);
 
         let mut stream = resp.bytes_stream();
         let mut downloaded = existing_size;
@@ -338,7 +351,7 @@ impl HttpDownloader {
         while let Some(chunk) = stream.next().await {
             let chunk = chunk.map_err(crate::Error::Http)?;
             self.bandwidth.acquire(chunk.len() as u64).await;
-            file.write_all(&chunk).await?;
+            writer.write_all(&chunk).await?;
             downloaded += chunk.len() as u64;
             speed_bytes += chunk.len() as u64;
 
@@ -356,7 +369,8 @@ impl HttpDownloader {
             }
         }
 
-        fsync_file(&mut file).await?;
+        writer.flush().await?;
+        fsync_file(writer.get_mut()).await?;
         info!("Resume download complete: {} bytes total", downloaded);
         Ok(downloaded)
     }
@@ -398,7 +412,7 @@ async fn download_chunk(
         .await?
         .error_for_status()?;
 
-    let mut file = if existing_bytes > 0 {
+    let file = if existing_bytes > 0 {
         tokio::fs::OpenOptions::new()
             .append(true)
             .open(chunk_path)
@@ -406,6 +420,7 @@ async fn download_chunk(
     } else {
         tokio::fs::File::create(chunk_path).await?
     };
+    let mut writer = tokio::io::BufWriter::with_capacity(WRITE_BUFFER_SIZE, file);
 
     let mut stream = resp.bytes_stream();
     let mut chunk_downloaded = existing_bytes;
@@ -413,7 +428,7 @@ async fn download_chunk(
     while let Some(data) = stream.next().await {
         let data = data.map_err(crate::Error::Http)?;
         bandwidth.acquire(data.len() as u64).await;
-        file.write_all(&data).await?;
+        writer.write_all(&data).await?;
         chunk_downloaded += data.len() as u64;
         progress[chunk_index as usize]
             .store(chunk_downloaded, std::sync::atomic::Ordering::Relaxed);
@@ -421,7 +436,8 @@ async fn download_chunk(
 
     // Each chunk gets fsync'd so its bytes survive a crash before the
     // reassembly stage reads it back.
-    fsync_file(&mut file).await?;
+    writer.flush().await?;
+    fsync_file(writer.get_mut()).await?;
     debug!("Chunk {chunk_index} complete: {chunk_downloaded} bytes");
     Ok(())
 }

--- a/crates/core/src/protocol/http.rs
+++ b/crates/core/src/protocol/http.rs
@@ -465,9 +465,24 @@ async fn download_segment(
         progress[idx].store(downloaded, std::sync::atomic::Ordering::Relaxed);
     }
 
+    // Only flush to the kernel — no per-segment fsync. These temp files are
+    // scratch: never resumed after a crash and deleted right after
+    // reassembly, so flushing is enough for the reassembly read to see the
+    // bytes. Durability is provided by the single fsync of the final output.
     writer.flush().await?;
-    fsync_file(writer.get_mut()).await?;
     Ok(downloaded)
+}
+
+/// Aborts a spawned task when dropped. Used to tie the progress-reporter task
+/// to the lifetime of the download future, so a `tokio::select!` cancellation
+/// (which drops the future before the normal cleanup runs) doesn't leak the
+/// reporter for the rest of the process.
+struct AbortOnDrop(tokio::task::JoinHandle<()>);
+
+impl Drop for AbortOnDrop {
+    fn drop(&mut self) {
+        self.0.abort();
+    }
 }
 
 /// Download a list of media segments (HLS/DASH) concurrently to indexed temp
@@ -503,8 +518,10 @@ pub(crate) async fn download_segments_streamed(
     );
 
     // Emit aggregate progress on a timer rather than once per segment, so a
-    // stream with thousands of segments doesn't flood the watch channel.
-    let progress_reporter = {
+    // stream with thousands of segments doesn't flood the watch channel. The
+    // AbortOnDrop guard stops the reporter even if this future is dropped on
+    // cancellation before the normal cleanup runs.
+    let progress_reporter = AbortOnDrop({
         let progress = seg_progress.clone();
         let tx = progress_tx.clone();
         tokio::spawn(async move {
@@ -529,7 +546,7 @@ pub(crate) async fn download_segments_streamed(
                 last_time = now;
             }
         })
-    };
+    });
 
     let work: Result<u64, crate::Error> = async {
         // Download in bounded-concurrency batches, preserving global indices.
@@ -546,12 +563,23 @@ pub(crate) async fn download_segments_streamed(
                     download_segment(&client, &url, &seg_path, idx, &progress).await
                 }));
             }
+            // Await the entire batch before propagating any error, so a single
+            // failure doesn't detach the remaining tasks (a dropped JoinHandle
+            // keeps running and would race the error-path cleanup of seg_dir).
+            let mut first_err: Option<crate::Error> = None;
             for handle in handles {
                 match handle.await {
                     Ok(Ok(_)) => {}
-                    Ok(Err(e)) => return Err(e),
-                    Err(e) => return Err(crate::Error::Other(e.to_string())),
+                    Ok(Err(e)) => {
+                        first_err.get_or_insert(e);
+                    }
+                    Err(e) => {
+                        first_err.get_or_insert(crate::Error::Other(e.to_string()));
+                    }
                 }
+            }
+            if let Some(e) = first_err {
+                return Err(e);
             }
             base += batch.len();
             debug!("segments: downloaded {base}/{total_segments}");
@@ -578,7 +606,9 @@ pub(crate) async fn download_segments_streamed(
     }
     .await;
 
-    progress_reporter.abort();
+    // Stop the reporter before emitting the final progress so a stale tick
+    // can't overwrite it. (On cancellation the guard's Drop handles this.)
+    drop(progress_reporter);
 
     match work {
         Ok(total_bytes) => {

--- a/crates/core/src/protocol/http.rs
+++ b/crates/core/src/protocol/http.rs
@@ -3,6 +3,7 @@
 //! Supports multi-chunk parallel downloads, resume, and progress reporting.
 
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use futures::StreamExt;
 use reqwest::header::{ACCEPT_RANGES, CONTENT_DISPOSITION, CONTENT_LENGTH, RANGE};
@@ -440,6 +441,161 @@ async fn download_chunk(
     fsync_file(writer.get_mut()).await?;
     debug!("Chunk {chunk_index} complete: {chunk_downloaded} bytes");
     Ok(())
+}
+
+/// Stream a single media segment (full GET, no range) to `seg_path`, updating
+/// `progress[idx]` as bytes arrive. Returns the segment's byte count.
+async fn download_segment(
+    client: &reqwest::Client,
+    url: &str,
+    seg_path: &Path,
+    idx: usize,
+    progress: &[std::sync::atomic::AtomicU64],
+) -> Result<u64, crate::Error> {
+    let resp = client.get(url).send().await?.error_for_status()?;
+    let file = tokio::fs::File::create(seg_path).await?;
+    let mut writer = tokio::io::BufWriter::with_capacity(WRITE_BUFFER_SIZE, file);
+    let mut stream = resp.bytes_stream();
+    let mut downloaded: u64 = 0;
+
+    while let Some(data) = stream.next().await {
+        let data = data.map_err(crate::Error::Http)?;
+        writer.write_all(&data).await?;
+        downloaded += data.len() as u64;
+        progress[idx].store(downloaded, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    writer.flush().await?;
+    fsync_file(writer.get_mut()).await?;
+    Ok(downloaded)
+}
+
+/// Download a list of media segments (HLS/DASH) concurrently to indexed temp
+/// files and reassemble them in playlist order into `dest`.
+///
+/// Shared by the HLS and DASH backends. Unlike the previous approach this never
+/// holds the whole stream in RAM: each segment streams straight to
+/// `seg_dir/seg_{idx:08}` and reassembly copies them through one buffered
+/// writer, so peak memory is bounded by the concurrency, not the stream size.
+/// Output is written to a sibling `.part` file and atomically renamed on
+/// success (matching the durability guarantees of the chunked HTTP path).
+/// Progress is emitted on a 500 ms timer instead of once per segment.
+pub(crate) async fn download_segments_streamed(
+    client: &reqwest::Client,
+    segment_urls: &[String],
+    dest: &Path,
+    seg_dir: &Path,
+    concurrent_segments: usize,
+    progress_tx: watch::Sender<DownloadProgress>,
+) -> Result<u64, crate::Error> {
+    let total_segments = segment_urls.len();
+    let concurrency = concurrent_segments.max(1);
+
+    tokio::fs::create_dir_all(seg_dir).await?;
+    if let Some(parent) = dest.parent() {
+        tokio::fs::create_dir_all(parent).await?;
+    }
+
+    let seg_progress = Arc::new(
+        (0..total_segments)
+            .map(|_| std::sync::atomic::AtomicU64::new(0))
+            .collect::<Vec<_>>(),
+    );
+
+    // Emit aggregate progress on a timer rather than once per segment, so a
+    // stream with thousands of segments doesn't flood the watch channel.
+    let progress_reporter = {
+        let progress = seg_progress.clone();
+        let tx = progress_tx.clone();
+        tokio::spawn(async move {
+            let mut last_total: u64 = 0;
+            let mut last_time = tokio::time::Instant::now();
+            loop {
+                tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+                let total: u64 = progress
+                    .iter()
+                    .map(|a| a.load(std::sync::atomic::Ordering::Relaxed))
+                    .sum();
+                let now = tokio::time::Instant::now();
+                let elapsed = now.duration_since(last_time);
+                let speed = bytes_per_sec(total.saturating_sub(last_total), elapsed);
+                // total_bytes stays None: segment sizes are unknown up front.
+                let _ = tx.send(DownloadProgress {
+                    bytes_downloaded: total,
+                    total_bytes: None,
+                    speed_bytes_per_sec: speed,
+                });
+                last_total = total;
+                last_time = now;
+            }
+        })
+    };
+
+    let work: Result<u64, crate::Error> = async {
+        // Download in bounded-concurrency batches, preserving global indices.
+        let mut base = 0usize;
+        for batch in segment_urls.chunks(concurrency) {
+            let mut handles = Vec::with_capacity(batch.len());
+            for (offset, url) in batch.iter().enumerate() {
+                let idx = base + offset;
+                let client = client.clone();
+                let url = url.clone();
+                let seg_path = seg_dir.join(format!("seg_{idx:08}"));
+                let progress = seg_progress.clone();
+                handles.push(tokio::spawn(async move {
+                    download_segment(&client, &url, &seg_path, idx, &progress).await
+                }));
+            }
+            for handle in handles {
+                match handle.await {
+                    Ok(Ok(_)) => {}
+                    Ok(Err(e)) => return Err(e),
+                    Err(e) => return Err(crate::Error::Other(e.to_string())),
+                }
+            }
+            base += batch.len();
+            debug!("segments: downloaded {base}/{total_segments}");
+        }
+
+        // Reassemble in index order through a single buffered writer.
+        let dest_tmp = dest.with_extension("part");
+        let dest_file = tokio::fs::File::create(&dest_tmp).await?;
+        let mut writer = tokio::io::BufWriter::with_capacity(WRITE_BUFFER_SIZE, dest_file);
+        let mut total_bytes: u64 = 0;
+        for i in 0..total_segments {
+            let seg_path = seg_dir.join(format!("seg_{i:08}"));
+            let mut seg_file = tokio::fs::File::open(&seg_path).await?;
+            total_bytes += tokio::io::copy(&mut seg_file, &mut writer).await?;
+            drop(seg_file);
+            tokio::fs::remove_file(&seg_path).await?;
+        }
+        writer.flush().await?;
+        fsync_file(writer.get_mut()).await?;
+        drop(writer);
+        tokio::fs::rename(&dest_tmp, dest).await?;
+        fsync_parent(dest).await;
+        Ok(total_bytes)
+    }
+    .await;
+
+    progress_reporter.abort();
+
+    match work {
+        Ok(total_bytes) => {
+            let _ = tokio::fs::remove_dir_all(seg_dir).await;
+            let _ = progress_tx.send(DownloadProgress {
+                bytes_downloaded: total_bytes,
+                total_bytes: Some(total_bytes),
+                speed_bytes_per_sec: 0,
+            });
+            Ok(total_bytes)
+        }
+        Err(e) => {
+            let _ = tokio::fs::remove_file(dest.with_extension("part")).await;
+            let _ = tokio::fs::remove_dir_all(seg_dir).await;
+            Err(e)
+        }
+    }
 }
 
 /// Compute a transfer rate in bytes/sec, guarding against a zero (or

--- a/crates/core/src/storage.rs
+++ b/crates/core/src/storage.rs
@@ -313,7 +313,18 @@ impl Storage {
         std::fs::create_dir_all(&download_dir)?;
         std::fs::create_dir_all(&temp_dir)?;
         let conn = Connection::open(&db_path)?;
-        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
+        // WAL + synchronous=NORMAL is the recommended high-throughput pairing:
+        // durable across application crashes, only risking the last transaction
+        // on power loss. busy_timeout avoids spurious SQLITE_BUSY under the
+        // concurrent access the server generates; temp_store=MEMORY keeps
+        // sorting/temp B-trees off disk.
+        conn.execute_batch(
+            "PRAGMA journal_mode=WAL;
+             PRAGMA foreign_keys=ON;
+             PRAGMA synchronous=NORMAL;
+             PRAGMA busy_timeout=5000;
+             PRAGMA temp_store=MEMORY;",
+        )?;
         conn.execute_batch(SCHEMA)?;
         ensure_active_url_index(&conn)?;
         Ok(Self {
@@ -371,7 +382,7 @@ impl Storage {
 
     pub async fn get_download(&self, id: &str) -> Result<Option<DownloadRow>, crate::Error> {
         let db = self.db.lock().await;
-        let mut stmt = db.prepare(
+        let mut stmt = db.prepare_cached(
             "SELECT id, url, protocol, filename, filesize, status, priority, package_id, plugin_id,
                     download_dir, bytes_downloaded, speed_current, error_message, retry_count,
                     created_at, started_at, completed_at
@@ -381,9 +392,26 @@ impl Storage {
         Ok(rows.next().transpose()?)
     }
 
+    /// Find the id of an active (queued/downloading/paused) download for `url`,
+    /// if any. Indexed point lookup — avoids scanning the whole table for the
+    /// duplicate-detection check on the add path.
+    pub async fn find_active_download_by_url(
+        &self,
+        url: &str,
+    ) -> Result<Option<String>, crate::Error> {
+        let db = self.db.lock().await;
+        let mut stmt = db.prepare_cached(
+            "SELECT id FROM downloads
+             WHERE url = ?1 AND status IN ('queued', 'downloading', 'paused')
+             LIMIT 1",
+        )?;
+        let mut rows = stmt.query_map(rusqlite::params![url], |r| r.get::<_, String>(0))?;
+        Ok(rows.next().transpose()?)
+    }
+
     pub async fn list_downloads(&self) -> Result<Vec<DownloadRow>, crate::Error> {
         let db = self.db.lock().await;
-        let mut stmt = db.prepare(
+        let mut stmt = db.prepare_cached(
             "SELECT id, url, protocol, filename, filesize, status, priority, package_id, plugin_id,
                     download_dir, bytes_downloaded, speed_current, error_message, retry_count,
                     created_at, started_at, completed_at
@@ -399,7 +427,7 @@ impl Storage {
     ) -> Result<Vec<DownloadRow>, crate::Error> {
         let db = self.db.lock().await;
         let status_str = status.as_str();
-        let mut stmt = db.prepare(
+        let mut stmt = db.prepare_cached(
             "SELECT id, url, protocol, filename, filesize, status, priority, package_id, plugin_id,
                     download_dir, bytes_downloaded, speed_current, error_message, retry_count,
                     created_at, started_at, completed_at
@@ -554,17 +582,22 @@ impl Storage {
         chunks: &[crate::chunk::Chunk],
         temp_dir: &std::path::Path,
     ) -> Result<(), crate::Error> {
-        let db = self.db.lock().await;
-        db.execute(
+        let mut db = self.db.lock().await;
+        // One transaction for the delete + all inserts: a single commit/fsync
+        // instead of one per chunk, and the INSERT is prepared once.
+        let tx = db.transaction()?;
+        tx.execute(
             "DELETE FROM chunks WHERE download_id = ?1",
             rusqlite::params![download_id],
         )?;
-        for chunk in chunks {
-            let temp_path = temp_dir.join(format!("chunk_{}", chunk.index));
-            db.execute(
+        {
+            let mut stmt = tx.prepare_cached(
                 "INSERT INTO chunks (id, download_id, chunk_index, start_byte, end_byte, bytes_downloaded, status, temp_path)
                  VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
-                rusqlite::params![
+            )?;
+            for chunk in chunks {
+                let temp_path = temp_dir.join(format!("chunk_{}", chunk.index));
+                stmt.execute(rusqlite::params![
                     format!("{download_id}_chunk_{}", chunk.index),
                     download_id,
                     chunk.index,
@@ -573,9 +606,10 @@ impl Storage {
                     chunk.bytes_downloaded,
                     format!("{:?}", chunk.status).to_lowercase(),
                     temp_path.to_string_lossy(),
-                ],
-            )?;
+                ])?;
+            }
         }
+        tx.commit()?;
         Ok(())
     }
 

--- a/crates/extractors/Cargo.toml
+++ b/crates/extractors/Cargo.toml
@@ -5,7 +5,6 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/extractors/src/generic/mod.rs
+++ b/crates/extractors/src/generic/mod.rs
@@ -12,12 +12,27 @@
 pub mod metadata;
 pub mod players;
 
+use std::sync::LazyLock;
+
 use regex::Regex;
 use scraper::{Html, Selector};
 use tracing::{debug, info};
 use url::Url;
 
 use crate::error::ExtractorError;
+
+// Media-URL mining patterns are static; compile once instead of per page.
+static SCRIPT_M3U8_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"["\']?(https?://[^"'\s]+\.m3u8(?:\?[^"'\s]*)?)["\']?"#).unwrap()
+});
+static SCRIPT_MPD_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"["\']?(https?://[^"'\s]+\.mpd(?:\?[^"'\s]*)?)["\']?"#).unwrap());
+static SCRIPT_MP4_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"["\']?(https?://[^"'\s]+\.(?:mp4|webm)(?:\?[^"'\s]*)?)["\']?"#).unwrap()
+});
+static FEED_ENCLOSURE_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"<enclosure[^>]+url=["']([^"']+)["'][^>]*(?:type=["']([^"']+)["'])?"#).unwrap()
+});
 use crate::traits::{ExtractedMedia, Extractor, MediaStream, StreamProtocol};
 
 /// Media file extensions that indicate a direct download.
@@ -175,9 +190,7 @@ impl GenericExtractor {
         let mut streams = Vec::new();
 
         // Find m3u8 URLs
-        let m3u8_re =
-            Regex::new(r#"["\']?(https?://[^"'\s]+\.m3u8(?:\?[^"'\s]*)?)["\']?"#).unwrap();
-        for cap in m3u8_re.captures_iter(html) {
+        for cap in SCRIPT_M3U8_RE.captures_iter(html) {
             if let Some(url) = cap.get(1) {
                 debug!("Found m3u8 in script: {}", url.as_str());
                 streams.push(Self::stream_from_url(url.as_str(), StreamProtocol::Hls));
@@ -185,8 +198,7 @@ impl GenericExtractor {
         }
 
         // Find mpd URLs
-        let mpd_re = Regex::new(r#"["\']?(https?://[^"'\s]+\.mpd(?:\?[^"'\s]*)?)["\']?"#).unwrap();
-        for cap in mpd_re.captures_iter(html) {
+        for cap in SCRIPT_MPD_RE.captures_iter(html) {
             if let Some(url) = cap.get(1) {
                 debug!("Found mpd in script: {}", url.as_str());
                 streams.push(Self::stream_from_url(url.as_str(), StreamProtocol::Dash));
@@ -194,9 +206,7 @@ impl GenericExtractor {
         }
 
         // Find direct mp4/webm URLs in JavaScript (but not in HTML href/src which we handle elsewhere)
-        let mp4_re =
-            Regex::new(r#"["\']?(https?://[^"'\s]+\.(?:mp4|webm)(?:\?[^"'\s]*)?)["\']?"#).unwrap();
-        for cap in mp4_re.captures_iter(html) {
+        for cap in SCRIPT_MP4_RE.captures_iter(html) {
             if let Some(url) = cap.get(1) {
                 let url_str = url.as_str();
                 // Skip obvious non-video mp4 URLs (thumbnails, etc.)
@@ -257,10 +267,7 @@ impl GenericExtractor {
         let mut streams = Vec::new();
 
         // RSS <enclosure url="..." type="..."/>
-        let enclosure_re =
-            Regex::new(r#"<enclosure[^>]+url=["']([^"']+)["'][^>]*(?:type=["']([^"']+)["'])?"#)
-                .unwrap();
-        for cap in enclosure_re.captures_iter(html) {
+        for cap in FEED_ENCLOSURE_RE.captures_iter(html) {
             if let Some(url) = cap.get(1) {
                 let url_str = url.as_str();
                 let ct = cap.get(2).map(|m| m.as_str()).unwrap_or("");

--- a/crates/extractors/src/generic/players.rs
+++ b/crates/extractors/src/generic/players.rs
@@ -7,12 +7,45 @@
 //! - Flowplayer
 //! - Wistia
 
+use std::sync::LazyLock;
+
 use regex::Regex;
 use tracing::debug;
 
 use crate::traits::{MediaStream, StreamProtocol};
 
 use super::{GenericExtractor, resolve_url};
+
+// Player-detection patterns are static; compile them once instead of on every
+// page extraction (these functions run for every candidate video page).
+static JW_SETUP_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r#"jwplayer\s*\([^)]*\)\s*\.\s*setup\s*\(\s*\{[^}]*?["']?file["']?\s*:\s*["']([^"']+)["']"#,
+    )
+    .unwrap()
+});
+static JW_FILE_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"["']?file["']?\s*:\s*["'](https?://[^"']+)["']"#).unwrap());
+static JW_SOURCES_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"["']?sources["']?\s*:\s*\[([^\]]+)\]"#).unwrap());
+static VIDEOJS_DATA_SETUP_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"data-setup\s*=\s*'([^']+)'"#).unwrap());
+static VIDEOJS_SRC_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"\.src\s*\(\s*\{[^}]*["']?src["']?\s*:\s*["'](https?://[^"']+)["']"#).unwrap()
+});
+static BRIGHTCOVE_SRC_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"["']?src["']?\s*:\s*["'](https?://[^"']+\.(?:m3u8|mpd|mp4)[^"']*)["']"#).unwrap()
+});
+static FLOWPLAYER_SRC_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"["']?src["']?\s*:\s*["'](https?://[^"']+\.(?:m3u8|mpd|mp4|webm)[^"']*)["']"#)
+        .unwrap()
+});
+static WISTIA_ASSET_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r#"["']?url["']?\s*:\s*["'](https?://[^"']*wistia[^"']*\.(?:m3u8|mp4|bin)[^"']*)["']"#,
+    )
+    .unwrap()
+});
 
 /// Detect JW Player embeds and extract stream URLs.
 ///
@@ -25,11 +58,7 @@ pub fn detect_jwplayer(html: &str, base_url: &str) -> Vec<MediaStream> {
     let mut streams = Vec::new();
 
     // Pattern 1: jwplayer().setup() with file
-    let setup_re = Regex::new(
-        r#"jwplayer\s*\([^)]*\)\s*\.\s*setup\s*\(\s*\{[^}]*?["']?file["']?\s*:\s*["']([^"']+)["']"#,
-    )
-    .unwrap();
-    for cap in setup_re.captures_iter(html) {
+    for cap in JW_SETUP_RE.captures_iter(html) {
         if let Some(url) = cap.get(1) {
             add_media_stream(&mut streams, url.as_str(), base_url, "JW Player setup.file");
         }
@@ -37,8 +66,7 @@ pub fn detect_jwplayer(html: &str, base_url: &str) -> Vec<MediaStream> {
 
     // Pattern 2: Generic file property near jwplayer references
     if html.contains("jwplayer") || html.contains("jwDefaults") || html.contains("jw-video") {
-        let file_re = Regex::new(r#"["']?file["']?\s*:\s*["'](https?://[^"']+)["']"#).unwrap();
-        for cap in file_re.captures_iter(html) {
+        for cap in JW_FILE_RE.captures_iter(html) {
             if let Some(url) = cap.get(1) {
                 let url_str = url.as_str();
                 if GenericExtractor::is_media_url(url_str)
@@ -50,12 +78,10 @@ pub fn detect_jwplayer(html: &str, base_url: &str) -> Vec<MediaStream> {
             }
         }
 
-        // Pattern 3: sources array
-        let sources_re = Regex::new(r#"["']?sources["']?\s*:\s*\[([^\]]+)\]"#).unwrap();
-        let src_file_re = Regex::new(r#"["']?file["']?\s*:\s*["'](https?://[^"']+)["']"#).unwrap();
-        for cap in sources_re.captures_iter(html) {
+        // Pattern 3: sources array (reuses the file pattern for inner entries)
+        for cap in JW_SOURCES_RE.captures_iter(html) {
             if let Some(inner) = cap.get(1) {
-                for src_cap in src_file_re.captures_iter(inner.as_str()) {
+                for src_cap in JW_FILE_RE.captures_iter(inner.as_str()) {
                     if let Some(url) = src_cap.get(1) {
                         add_media_stream(&mut streams, url.as_str(), base_url, "JW Player sources");
                     }
@@ -76,8 +102,7 @@ pub fn detect_videojs(html: &str, base_url: &str) -> Vec<MediaStream> {
     let mut streams = Vec::new();
 
     // data-setup attribute with sources
-    let data_setup_re = Regex::new(r#"data-setup\s*=\s*'([^']+)'"#).unwrap();
-    for cap in data_setup_re.captures_iter(html) {
+    for cap in VIDEOJS_DATA_SETUP_RE.captures_iter(html) {
         if let Some(json) = cap
             .get(1)
             .and_then(|json_str| serde_json::from_str::<serde_json::Value>(json_str.as_str()).ok())
@@ -93,10 +118,7 @@ pub fn detect_videojs(html: &str, base_url: &str) -> Vec<MediaStream> {
 
     // videojs().src() calls
     if html.contains("videojs") || html.contains("video-js") {
-        let src_re =
-            Regex::new(r#"\.src\s*\(\s*\{[^}]*["']?src["']?\s*:\s*["'](https?://[^"']+)["']"#)
-                .unwrap();
-        for cap in src_re.captures_iter(html) {
+        for cap in VIDEOJS_SRC_RE.captures_iter(html) {
             if let Some(url) = cap.get(1) {
                 add_media_stream(&mut streams, url.as_str(), base_url, "Video.js src()");
             }
@@ -117,10 +139,7 @@ pub fn detect_brightcove(html: &str, base_url: &str) -> Vec<MediaStream> {
     // Brightcove often includes source URLs in data attributes or script configs
     if html.contains("brightcove") || html.contains("bc-player") || html.contains("data-video-id") {
         // Look for video sources in Brightcove config
-        let source_re =
-            Regex::new(r#"["']?src["']?\s*:\s*["'](https?://[^"']+\.(?:m3u8|mpd|mp4)[^"']*)["']"#)
-                .unwrap();
-        for cap in source_re.captures_iter(html) {
+        for cap in BRIGHTCOVE_SRC_RE.captures_iter(html) {
             if let Some(url) = cap.get(1) {
                 add_media_stream(&mut streams, url.as_str(), base_url, "Brightcove");
             }
@@ -139,11 +158,7 @@ pub fn detect_flowplayer(html: &str, base_url: &str) -> Vec<MediaStream> {
 
     if html.contains("flowplayer") {
         // Extract clip sources
-        let clip_re = Regex::new(
-            r#"["']?src["']?\s*:\s*["'](https?://[^"']+\.(?:m3u8|mpd|mp4|webm)[^"']*)["']"#,
-        )
-        .unwrap();
-        for cap in clip_re.captures_iter(html) {
+        for cap in FLOWPLAYER_SRC_RE.captures_iter(html) {
             if let Some(url) = cap.get(1) {
                 add_media_stream(&mut streams, url.as_str(), base_url, "Flowplayer");
             }
@@ -163,11 +178,7 @@ pub fn detect_wistia(html: &str, base_url: &str) -> Vec<MediaStream> {
 
     if html.contains("wistia") {
         // Wistia often embeds asset URLs in JSON config
-        let asset_re = Regex::new(
-            r#"["']?url["']?\s*:\s*["'](https?://[^"']*wistia[^"']*\.(?:m3u8|mp4|bin)[^"']*)["']"#,
-        )
-        .unwrap();
-        for cap in asset_re.captures_iter(html) {
+        for cap in WISTIA_ASSET_RE.captures_iter(html) {
             if let Some(url) = cap.get(1) {
                 add_media_stream(&mut streams, url.as_str(), base_url, "Wistia");
             }

--- a/crates/extractors/src/youtube/innertube.rs
+++ b/crates/extractors/src/youtube/innertube.rs
@@ -4,10 +4,19 @@
 //! without PO-tokens or signature decryption. Falls back to `web_embedded` and
 //! watch-page HTML extraction.
 
+use std::sync::LazyLock;
+
 use serde_json::Value;
 use tracing::{debug, info, warn};
 
 use crate::ExtractorError;
+
+// Player-JS URL patterns are static; compile once instead of per video extraction.
+static PLAYER_JS_PATH_RE: LazyLock<regex::Regex> = LazyLock::new(|| {
+    regex::Regex::new(r#"/s/player/[a-f0-9]+/player_ias\.vflset/[^/]+/base\.js"#).unwrap()
+});
+static PLAYER_JS_URL_RE: LazyLock<regex::Regex> =
+    LazyLock::new(|| regex::Regex::new(r#""jsUrl"\s*:\s*"([^"]+)""#).unwrap());
 
 /// Innertube client configuration.
 struct InnertubeClient {
@@ -219,18 +228,12 @@ pub async fn fetch_player_js_url(
     let html = resp.text().await?;
 
     // Look for player JS URL pattern: /s/player/<hash>/player_ias.vflset/en_US/base.js
-    let re = regex::Regex::new(r#"/s/player/[a-f0-9]+/player_ias\.vflset/[^/]+/base\.js"#)
-        .map_err(|e| ExtractorError::Other(e.to_string()))?;
-
-    if let Some(m) = re.find(&html) {
+    if let Some(m) = PLAYER_JS_PATH_RE.find(&html) {
         return Ok(format!("https://www.youtube.com{}", m.as_str()));
     }
 
     // Fallback pattern
-    let re2 = regex::Regex::new(r#""jsUrl"\s*:\s*"([^"]+)""#)
-        .map_err(|e| ExtractorError::Other(e.to_string()))?;
-
-    if let Some(caps) = re2.captures(&html)
+    if let Some(caps) = PLAYER_JS_URL_RE.captures(&html)
         && let Some(js_match) = caps.get(1)
     {
         let js_path = js_match.as_str();

--- a/crates/extractors/src/youtube/n_challenge.rs
+++ b/crates/extractors/src/youtube/n_challenge.rs
@@ -5,7 +5,7 @@
 //! player JS. This module extracts that function and runs it via QuickJS.
 
 use std::collections::HashMap;
-use std::sync::{LazyLock, Mutex};
+use std::sync::{Arc, LazyLock, Mutex};
 use std::time::{Duration, Instant};
 
 use regex::Regex;
@@ -64,7 +64,9 @@ const N_TRANSFORM_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Clone)]
 struct PlayerJsEntry {
-    js: String,
+    /// Player JS is ~1 MiB; store it behind an `Arc` so cache hits hand out a
+    /// cheap reference-count bump instead of copying the whole string.
+    js: Arc<str>,
     fetched_at: Instant,
 }
 
@@ -78,7 +80,7 @@ static PLAYER_JS_CACHE: std::sync::LazyLock<Mutex<HashMap<String, PlayerJsEntry>
 async fn get_player_js(
     client: &reqwest::Client,
     player_js_url: &str,
-) -> Result<String, ExtractorError> {
+) -> Result<Arc<str>, ExtractorError> {
     // Check cache, honouring TTL.
     {
         let mut cache = PLAYER_JS_CACHE.lock().unwrap_or_else(|e| e.into_inner());
@@ -100,7 +102,7 @@ async fn get_player_js(
         .send()
         .await?;
 
-    let js = resp.text().await?;
+    let js: Arc<str> = Arc::from(resp.text().await?);
 
     // Cache it, evicting the oldest entry first if we're at capacity.
     {

--- a/crates/extractors/src/youtube/n_challenge.rs
+++ b/crates/extractors/src/youtube/n_challenge.rs
@@ -5,12 +5,45 @@
 //! player JS. This module extracts that function and runs it via QuickJS.
 
 use std::collections::HashMap;
-use std::sync::Mutex;
+use std::sync::{LazyLock, Mutex};
 use std::time::{Duration, Instant};
 
+use regex::Regex;
 use tracing::{debug, warn};
 
 use crate::ExtractorError;
+
+/// The n-function reference pattern; static, so compile it once.
+static N_FUNC_REF_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"\.get\("n"\)\)&&\(b=([a-zA-Z0-9$]+)(?:\[(\d+)\])?\(b\)"#).unwrap()
+});
+
+/// Broader fallback pattern matching the whole n-transform function body.
+static N_FUNC_FALLBACK_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r#"(?s)function\s*\w+\(a\)\s*\{var b=a\.split\(""\).*?return b\.join\(""\)\}"#)
+        .unwrap()
+});
+
+/// Bounded cache for regexes built from runtime-derived function names. These
+/// patterns vary by player version but recur across retries / multiple videos
+/// on the same player, so caching avoids recompiling them each extraction.
+static DYNAMIC_RE_CACHE: LazyLock<Mutex<HashMap<String, Regex>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+const DYNAMIC_RE_CACHE_MAX_ENTRIES: usize = 32;
+
+/// Get-or-compile a regex for a dynamically built pattern, caching successes.
+fn cached_dynamic_regex(pattern: &str) -> Option<Regex> {
+    let mut cache = DYNAMIC_RE_CACHE.lock().unwrap_or_else(|e| e.into_inner());
+    if let Some(re) = cache.get(pattern) {
+        return Some(re.clone());
+    }
+    let re = Regex::new(pattern).ok()?;
+    if cache.len() >= DYNAMIC_RE_CACHE_MAX_ENTRIES {
+        cache.clear();
+    }
+    cache.insert(pattern.to_string(), re.clone());
+    Some(re)
+}
 
 /// Maximum age of a cached player.js entry. YouTube rotates the player JS
 /// roughly daily; refreshing every 12 h keeps us aligned without spamming
@@ -102,19 +135,9 @@ async fn get_player_js(
 /// We look for the function name assigned to handle the `n` parameter and
 /// extract the complete function body.
 fn extract_n_function(player_js: &str) -> Result<String, ExtractorError> {
-    // Pattern 1: Modern yt-dlp style — function name from n-parameter assignment
+    // Pattern 1: Modern yt-dlp style — function name from n-parameter assignment.
     // Looking for: var b=a.split("") ... .join("")
-    // The n-transform function pattern used by yt-dlp:
-    let patterns = [
-        // Enhanced swap function pattern
-        r#"\.get\("n"\)\)&&\(b=([a-zA-Z0-9$]+)(?:\[(\d+)\])?\(b\)"#,
-        // Alternative pattern
-        r#"var b=a\.split\(""\).*?return b\.join\(""\)"#,
-    ];
-
-    let re = regex::Regex::new(patterns[0]).map_err(|e| ExtractorError::Other(e.to_string()))?;
-
-    if let Some(caps) = re.captures(player_js) {
+    if let Some(caps) = N_FUNC_REF_RE.captures(player_js) {
         let func_name = caps
             .get(1)
             .ok_or_else(|| {
@@ -144,12 +167,7 @@ fn extract_n_function(player_js: &str) -> Result<String, ExtractorError> {
     }
 
     // Fallback: look for the complete n-transform function using a broader pattern
-    let fallback_re = regex::Regex::new(
-        r#"(?s)function\s*\w+\(a\)\s*\{var b=a\.split\(""\).*?return b\.join\(""\)\}"#,
-    )
-    .map_err(|e| ExtractorError::Other(e.to_string()))?;
-
-    if let Some(m) = fallback_re.find(player_js) {
+    if let Some(m) = N_FUNC_FALLBACK_RE.find(player_js) {
         return Ok(m.as_str().to_string());
     }
 
@@ -165,7 +183,7 @@ fn extract_named_function(js: &str, name: &str) -> Option<String> {
 
     // Try: var name=function(a){...};
     let pat = format!(r"(?s)var\s+{escaped}\s*=\s*function\([^)]*\)\s*\{{");
-    if let Ok(re) = regex::Regex::new(&pat)
+    if let Some(re) = cached_dynamic_regex(&pat)
         && let Some(m) = re.find(js)
         && let Some(end) = find_closing_brace(js, m.end() - 1)
     {
@@ -175,7 +193,7 @@ fn extract_named_function(js: &str, name: &str) -> Option<String> {
 
     // Try: function name(a){...}
     let pat2 = format!(r"(?s)function\s+{escaped}\s*\([^)]*\)\s*\{{");
-    if let Ok(re) = regex::Regex::new(&pat2)
+    if let Some(re) = cached_dynamic_regex(&pat2)
         && let Some(m) = re.find(js)
         && let Some(end) = find_closing_brace(js, m.end() - 1)
     {
@@ -189,7 +207,7 @@ fn extract_named_function(js: &str, name: &str) -> Option<String> {
 fn extract_function_from_array(js: &str, array_name: &str, _idx: usize) -> Option<String> {
     let escaped = regex::escape(array_name);
     let pat = format!(r"(?s)var\s+{escaped}\s*=\s*\[");
-    let re = regex::Regex::new(&pat).ok()?;
+    let re = cached_dynamic_regex(&pat)?;
     let m = re.find(js)?;
 
     // Find the closing bracket

--- a/crates/plugin-runtime/src/registry.rs
+++ b/crates/plugin-runtime/src/registry.rs
@@ -3,14 +3,33 @@
 //! Fetches the plugin index from a remote repository (GitHub),
 //! compares versions, and downloads plugin files with SHA256 verification.
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::{LazyLock, Mutex};
 
 use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use regex::Regex;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tracing::{debug, info, warn};
 
 use crate::types::PluginMeta;
+
+/// Cache of compiled URL-pattern regexes, keyed by the pattern string. The
+/// suggest endpoint recompiled every plugin's pattern on every request; the
+/// patterns are stable, so compile each at most once across requests.
+static URL_PATTERN_CACHE: LazyLock<Mutex<HashMap<String, Option<Regex>>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Get-or-compile the regex for a plugin URL pattern. Invalid patterns cache a
+/// `None` sentinel so they're skipped (as before) without retrying compilation.
+fn url_pattern_regex(pattern: &str) -> Option<Regex> {
+    let mut cache = URL_PATTERN_CACHE.lock().unwrap_or_else(|e| e.into_inner());
+    cache
+        .entry(pattern.to_string())
+        .or_insert_with(|| Regex::new(pattern).ok())
+        .clone()
+}
 
 /// Ed25519 public key of the amigo-labs plugin registry signer.
 ///
@@ -346,7 +365,7 @@ pub fn suggest_plugin_for_url<'a>(
     url: &str,
 ) -> Option<&'a RegistryPlugin> {
     for plugin in &index.plugins {
-        if let Ok(re) = regex::Regex::new(&plugin.url_pattern)
+        if let Some(re) = url_pattern_regex(&plugin.url_pattern)
             && re.is_match(url)
         {
             return Some(plugin);
@@ -421,6 +440,46 @@ pub async fn download_plugin(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn plugin_with_pattern(id: &str, pattern: &str) -> RegistryPlugin {
+        RegistryPlugin {
+            id: id.into(),
+            name: id.into(),
+            version: "1.0.0".into(),
+            description: String::new(),
+            author: String::new(),
+            url_pattern: pattern.into(),
+            min_app_version: None,
+            sha256: String::new(),
+            download_url: "https://example.com/p.ts".into(),
+            tags: vec![],
+        }
+    }
+
+    #[test]
+    fn test_suggest_plugin_for_url_matches_and_is_stable() {
+        let index = RegistryIndex {
+            schema_version: 1,
+            plugins: vec![
+                plugin_with_pattern("mega", r"https?://mega\.nz/.+"),
+                plugin_with_pattern("example", r"https?://example\.com/.+"),
+            ],
+        };
+
+        // Same query twice exercises the compiled-pattern cache path.
+        let url = "https://example.com/file/123";
+        assert_eq!(suggest_plugin_for_url(&index, url).unwrap().id, "example");
+        assert_eq!(suggest_plugin_for_url(&index, url).unwrap().id, "example");
+        assert!(suggest_plugin_for_url(&index, "https://nomatch.test/x").is_none());
+    }
+
+    #[test]
+    fn test_url_pattern_regex_caches_invalid_as_none() {
+        // An invalid pattern must yield None (skipped) without panicking,
+        // and a repeated lookup must stay None.
+        assert!(url_pattern_regex("(((unbalanced").is_none());
+        assert!(url_pattern_regex("(((unbalanced").is_none());
+    }
 
     #[test]
     fn test_check_plugin_updates_detects_update() {

--- a/crates/plugin-runtime/src/transpiler.rs
+++ b/crates/plugin-runtime/src/transpiler.rs
@@ -27,6 +27,13 @@ use swc_ecma_transforms_typescript::typescript;
 static TRANSPILE_CACHE: LazyLock<Mutex<HashMap<String, String>>> =
     LazyLock::new(|| Mutex::new(HashMap::new()));
 
+/// Cap on cached transpile outputs. Each plugin edit / hot-reload produces a
+/// new content hash, so without a bound a long-running server would retain
+/// every historical version's source+output forever. A handful of plugins are
+/// ever live; this is generous. On overflow we clear wholesale (a miss just
+/// re-transpiles), matching the eviction style used elsewhere in the crate.
+const TRANSPILE_CACHE_MAX_ENTRIES: usize = 128;
+
 /// Transpile TypeScript source code to JavaScript (ES2023).
 ///
 /// Only strips type annotations — no downlevel transformation.
@@ -52,10 +59,13 @@ pub fn transpile(source: &str, filename: &str) -> Result<String, crate::Error> {
     // two threads transpile identical input once, which is harmless.
     let js = transpile_uncached(source, filename)?;
 
-    TRANSPILE_CACHE
-        .lock()
-        .unwrap_or_else(|e| e.into_inner())
-        .insert(key, js.clone());
+    {
+        let mut cache = TRANSPILE_CACHE.lock().unwrap_or_else(|e| e.into_inner());
+        if cache.len() >= TRANSPILE_CACHE_MAX_ENTRIES {
+            cache.clear();
+        }
+        cache.insert(key, js.clone());
+    }
 
     Ok(js)
 }

--- a/crates/plugin-runtime/src/transpiler.rs
+++ b/crates/plugin-runtime/src/transpiler.rs
@@ -3,8 +3,11 @@
 //! Strips type annotations, interfaces, enums, and other TS-only syntax
 //! to produce clean ES2023 JavaScript that QuickJS-NG can execute.
 
+use std::collections::HashMap;
 use std::path::Path;
+use std::sync::{LazyLock, Mutex};
 
+use sha2::{Digest, Sha256};
 use swc_common::input::SourceFileInput;
 use swc_common::sync::Lrc;
 use swc_common::{FileName, GLOBALS, Globals, Mark, SourceMap};
@@ -15,11 +18,50 @@ use swc_ecma_parser::lexer::Lexer;
 use swc_ecma_parser::{Parser, Syntax, TsSyntax};
 use swc_ecma_transforms_typescript::typescript;
 
+/// Process-wide cache of transpiled output, keyed by a SHA-256 of the source +
+/// filename. SWC parsing/codegen is expensive and runs on every plugin load,
+/// hot-reload, and registry install; identical source short-circuits here.
+/// Keyed on content (not path/mtime) so an edited-then-reloaded plugin misses
+/// correctly. Touched from multiple worker threads, hence the sync Mutex —
+/// never held across an await (transpile is fully synchronous).
+static TRANSPILE_CACHE: LazyLock<Mutex<HashMap<String, String>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
 /// Transpile TypeScript source code to JavaScript (ES2023).
 ///
 /// Only strips type annotations — no downlevel transformation.
 /// The output is valid ES2023 that QuickJS-NG can execute directly.
 pub fn transpile(source: &str, filename: &str) -> Result<String, crate::Error> {
+    let key = {
+        let mut hasher = Sha256::new();
+        hasher.update(filename.as_bytes());
+        hasher.update([0u8]);
+        hasher.update(source.as_bytes());
+        hex::encode(hasher.finalize())
+    };
+
+    if let Some(cached) = TRANSPILE_CACHE
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .get(&key)
+    {
+        return Ok(cached.clone());
+    }
+
+    // Run the (expensive) transpile outside the lock; a lost race just means
+    // two threads transpile identical input once, which is harmless.
+    let js = transpile_uncached(source, filename)?;
+
+    TRANSPILE_CACHE
+        .lock()
+        .unwrap_or_else(|e| e.into_inner())
+        .insert(key, js.clone());
+
+    Ok(js)
+}
+
+/// Run the SWC parse → strip → codegen pipeline without consulting the cache.
+fn transpile_uncached(source: &str, filename: &str) -> Result<String, crate::Error> {
     GLOBALS.set(&Globals::new(), || {
         let cm: Lrc<SourceMap> = Lrc::new(SourceMap::default());
         let fm = cm.new_source_file(
@@ -93,6 +135,17 @@ mod tests {
         let js = transpile(ts, "test.ts").unwrap();
         assert!(js.contains("function hello"));
         assert!(!js.contains(": string"));
+    }
+
+    #[test]
+    fn test_transpile_cache_returns_identical_output() {
+        // Use a unique source so this test is independent of cache state.
+        let ts = r#"const cacheProbe: number = 7; function probe(): number { return cacheProbe; }"#;
+        let first = transpile(ts, "cache_probe.ts").unwrap();
+        let second = transpile(ts, "cache_probe.ts").unwrap();
+        assert_eq!(first, second);
+        // Output must match an uncached run too (cache is transparent).
+        assert_eq!(first, transpile_uncached(ts, "cache_probe.ts").unwrap());
     }
 
     #[test]

--- a/crates/server/src/background.rs
+++ b/crates/server/src/background.rs
@@ -2,12 +2,22 @@
 //! periodic plugin auto-updates.
 
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 use amigo_core::coordinator::Coordinator;
 use amigo_plugin_runtime::updater::PluginUpdater;
+use regex::Regex;
 use tokio::time::{Duration, interval};
 use tracing::{debug, info, warn};
+
+// RSS/Atom NZB-link patterns are static; compile once instead of on every
+// feed poll cycle (runs every 10-60s per configured feed).
+static NZB_ENCLOSURE_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"<enclosure[^>]+url=["']([^"']+\.nzb[^"']*)["']"#).unwrap());
+static NZB_LINK_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"<link[^>]*>([^<]+\.nzb[^<]*)</link>"#).unwrap());
+static NZB_HREF_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"href=["']([^"']+\.nzb[^"']*)["']"#).unwrap());
 
 /// Start all background tasks.
 pub fn spawn_background_tasks(
@@ -302,17 +312,14 @@ fn extract_nzb_links(xml: &str) -> Vec<String> {
     let mut links = Vec::new();
 
     // Find enclosure URLs with .nzb
-    let enclosure_pattern =
-        regex::Regex::new(r#"<enclosure[^>]+url=["']([^"']+\.nzb[^"']*)["']"#).unwrap();
-    for cap in enclosure_pattern.captures_iter(xml) {
+    for cap in NZB_ENCLOSURE_RE.captures_iter(xml) {
         if let Some(url) = cap.get(1) {
             links.push(url.as_str().to_string());
         }
     }
 
     // Find <link> elements pointing to .nzb files
-    let link_pattern = regex::Regex::new(r#"<link[^>]*>([^<]+\.nzb[^<]*)</link>"#).unwrap();
-    for cap in link_pattern.captures_iter(xml) {
+    for cap in NZB_LINK_RE.captures_iter(xml) {
         if let Some(url) = cap.get(1) {
             let url = url.as_str().trim();
             if url.starts_with("http") {
@@ -322,8 +329,7 @@ fn extract_nzb_links(xml: &str) -> Vec<String> {
     }
 
     // Find href attributes pointing to .nzb
-    let href_pattern = regex::Regex::new(r#"href=["']([^"']+\.nzb[^"']*)["']"#).unwrap();
-    for cap in href_pattern.captures_iter(xml) {
+    for cap in NZB_HREF_RE.captures_iter(xml) {
         if let Some(url) = cap.get(1) {
             links.push(url.as_str().to_string());
         }

--- a/crates/server/src/static_files.rs
+++ b/crates/server/src/static_files.rs
@@ -3,14 +3,26 @@
 //! In release builds, the web-ui dist/ folder is compiled into the binary.
 //! In dev, it falls through to a 404 (use vite dev server with proxy instead).
 
+use std::borrow::Cow;
+
 use axum::{
     Router,
+    body::Bytes,
     extract::Request,
     http::{StatusCode, header},
     response::{IntoResponse, Response},
     routing::get,
 };
 use rust_embed::Embed;
+
+/// Convert a rust-embed asset payload into `Bytes` without copying when the
+/// data is the `&'static [u8]` baked into the binary (the release case).
+fn embed_bytes(data: Cow<'static, [u8]>) -> Bytes {
+    match data {
+        Cow::Borrowed(b) => Bytes::from_static(b),
+        Cow::Owned(v) => Bytes::from(v),
+    }
+}
 
 #[derive(Embed)]
 #[folder = "../../web-ui/dist/"]
@@ -33,7 +45,7 @@ async fn serve_static(req: Request) -> Response {
                 (header::CONTENT_TYPE, mime.as_ref().to_string()),
                 (header::CACHE_CONTROL, cache_control(path).to_string()),
             ],
-            content.data.to_vec(),
+            embed_bytes(content.data),
         )
             .into_response();
     }
@@ -45,10 +57,10 @@ async fn serve_static(req: Request) -> Response {
         return (
             StatusCode::OK,
             [
-                (header::CONTENT_TYPE, "text/html".to_string()),
-                (header::CACHE_CONTROL, "no-cache".to_string()),
+                (header::CONTENT_TYPE, "text/html"),
+                (header::CACHE_CONTROL, "no-cache"),
             ],
-            index.data.to_vec(),
+            embed_bytes(index.data),
         )
             .into_response();
     }

--- a/web-ui/src/App.svelte
+++ b/web-ui/src/App.svelte
@@ -51,13 +51,20 @@
   } from "./lib/stores";
   import { locale, tr } from "./lib/i18n";
   import { addToast } from "./lib/toast";
-  import Downloads from "./pages/Downloads.svelte";
-  import History from "./pages/History.svelte";
-  import Login from "./pages/Login.svelte";
-  import Plugins from "./pages/Plugins.svelte";
-  import Settings from "./pages/Settings.svelte";
-  import Setup from "./pages/Setup.svelte";
   import PairingModal from "./components/PairingModal.svelte";
+
+  // Pages are code-split: each is fetched on first navigation rather than
+  // bundled into the initial payload, so the app shell loads faster. The
+  // browser caches the chunk after the first load.
+  type PageModule = { default: import("svelte").Component };
+  const pageLoaders: Record<string, () => Promise<PageModule>> = {
+    downloads: () => import("./pages/Downloads.svelte"),
+    plugins: () => import("./pages/Plugins.svelte"),
+    history: () => import("./pages/History.svelte"),
+    settings: () => import("./pages/Settings.svelte"),
+  };
+  const loadSetup = () => import("./pages/Setup.svelte");
+  const loadLogin = () => import("./pages/Login.svelte");
   import { authRequired, setupRequired } from "./lib/stores";
   import { getSetupStatus, me } from "./lib/api";
 
@@ -358,9 +365,15 @@
     <p style="color: var(--text-secondary)">Loading…</p>
   </div>
 {:else if bootState === "setup"}
-  <Setup />
+  {#await loadSetup() then mod}
+    {@const Setup = mod.default}
+    <Setup />
+  {/await}
 {:else if bootState === "login"}
-  <Login />
+  {#await loadLogin() then mod}
+    {@const Login = mod.default}
+    <Login />
+  {/await}
 {:else}
 <!-- Skip to content (audit L6) -->
 <a class="skip-link" href="#main-content">Skip to content</a>
@@ -706,14 +719,11 @@
         {#key pageKey}
           <div class="page-enter">
             <svelte:boundary onerror={(e) => console.error("Page error:", e)}>
-              {#if $currentPage === "downloads"}
-                <Downloads />
-              {:else if $currentPage === "plugins"}
-                <Plugins />
-              {:else if $currentPage === "history"}
-                <History />
-              {:else if $currentPage === "settings"}
-                <Settings />
+              {#if pageLoaders[$currentPage]}
+                {#await pageLoaders[$currentPage]() then mod}
+                  {@const Page = mod.default}
+                  <Page />
+                {/await}
               {/if}
             </svelte:boundary>
           </div>

--- a/web-ui/vite.config.ts
+++ b/web-ui/vite.config.ts
@@ -4,6 +4,22 @@ import tailwindcss from "@tailwindcss/vite";
 
 export default defineConfig({
   plugins: [svelte(), tailwindcss()],
+  build: {
+    cssCodeSplit: true,
+    // No production sourcemaps: the dist is embedded into the server binary,
+    // so shipping maps would only bloat it.
+    sourcemap: false,
+    rollupOptions: {
+      output: {
+        // Keep Svelte's runtime in its own long-lived vendor chunk so app
+        // changes don't bust its browser cache.
+        manualChunks(id) {
+          if (id.includes("node_modules/svelte")) return "vendor-svelte";
+          return undefined;
+        },
+      },
+    },
+  },
   server: {
     proxy: {
       "/api": "http://localhost:1516",


### PR DESCRIPTION
## Summary

Whole-repo performance pass spanning the Rust backend, build/dependencies, and the Svelte web UI. Each optimization is its own commit (safest first); all tests stay green.

## What changed (per commit)

1. **Release profile** — there was no `[profile.release]` at all. Added fat LTO, `codegen-units = 1`, `strip = "symbols"`.
2. **Regex caching** — hoisted hot-path regexes to `LazyLock` statics in the generic/YouTube extractors and RSS NZB parsing; bounded cache for the n-challenge patterns built from runtime-derived function names.
3. **Buffered I/O** — wrapped `download_single`/`download_resume`/`download_chunk` in a 256 KiB `BufWriter`; stream chunk reassembly via `tokio::io::copy` instead of reading whole chunks into RAM. Static assets served as zero-copy `Bytes::from_static`.
4. **SWC transpile cache** — process-wide cache keyed by SHA-256 of `(filename, source)`; registry URL-pattern regexes compiled once instead of per request.
5. **Player JS cache** — store the ~1 MiB YouTube player JS as `Arc<str>` so cache hits are a refcount bump, not a copy.
6. **tokio feature trim** — replaced `features = ["full"]` with the actual union (keeps `rt-multi-thread`, required by `block_in_place`; keeps `signal` for Tauri); dropped the tokio dependency from `amigo-extractors` entirely. Dev-deps still restore `full`.
7. **HLS/DASH streaming-to-disk** — segments now stream to indexed temp files and reassemble in order through one buffered writer instead of buffering the whole stream in RAM. Peak memory is now bounded by concurrency, not stream size. Output is written to a `.part` file and atomically renamed + fsynced (new crash durability for HLS/DASH). Progress is emitted on a 500 ms timer rather than per segment. Added a wiremock reassembly-order test (HLS/DASH had none).
8. **SQLite tuning** — `synchronous=NORMAL` + `busy_timeout` + `temp_store=MEMORY`; `prepare_cached` on hot read paths; `save_chunks` in one transaction with a reused INSERT; coordinator duplicate check is now an indexed point lookup instead of a full-table scan.
9. **`panic = "abort"`** (release only) — the codebase has no `catch_unwind`/`std::panic` recovery and rquickjs surfaces JS errors as `Err`, so this is safe and drops unwinding tables. Separate commit so it's independently revertible.
10. **Web UI code-splitting** — pages are lazy-loaded via dynamic import, the Svelte runtime is isolated into its own vendor chunk, and `cssCodeSplit` is enabled.

## Measured impact

- **Release binaries** (with all changes): `amigo-dl` 16.0 → **14.5 MB**, `amigo-server` 18.4 → **16.5 MB**.
- **Web UI initial critical-path JS**: single **186 kB / 56 kB gzip** bundle → **~43 kB gzip** (app shell + Svelte vendor), with Settings/Downloads/Plugins/History fetched on demand.
- **HLS/DASH peak RAM**: O(total stream size) → O(concurrency × segment buffer).

## Verification

- `cargo fmt --all --check` ✅, `cargo clippy --workspace --all-targets` clean ✅
- Full `cargo test --workspace` green (incl. new HLS reassembly-order test) ✅
- Whole-workspace build incl. Tauri ✅; release builds of server/cli/desktop link with `panic = "abort"` ✅
- Runtime smoke: CLI plugin resolve on the trimmed tokio feature set (exercises `block_in_place`) ✅

## Notes / deviations from plan

- **QuickJS runtime pooling was intentionally skipped.** The n-transform runs once per video extraction (dominated by network I/O), and pooling a thread-local runtime would accumulate cross-version global-scope state — real risk for negligible gain. The `Arc<str>` player-JS change captures the actual win.
- **tokio trim is moderate, not aggressive.** Cargo unions features workspace-wide, so per-crate `default-features=false` lists add the `block_in_place` → `rt-multi-thread` runtime-panic trap for little payoff. Dropping the extractors dep + `process`/`io-std` is the safe win.
- ⚠️ Do **not** run `cargo test --release` (incompatible with `panic = "abort"` on the test harness). Normal `cargo test` is unaffected.

https://claude.ai/code/session_01G8E5j2sYTqvFTNPZ1UkzSL

---
_Generated by [Claude Code](https://claude.ai/code/session_01G8E5j2sYTqvFTNPZ1UkzSL)_