### PR TITLE
feat(web-ui): "Command Deck" UI/UX redesign — palette, mobile nav, motion, i18n & a11y

### DIFF
--- a/packages/ui/src/components/Icon.svelte
+++ b/packages/ui/src/components/Icon.svelte
@@ -73,6 +73,9 @@
   {:else if name === "info"}
     <circle cx="12" cy="12" r="10" />
     <path d="M12 16v-4M12 8h.01" />
+  {:else if name === "alert"}
+    <path d="M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h16.9a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z" />
+    <path d="M12 9v4M12 17h.01" />
   {:else if name === "copy"}
     <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
     <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />

--- a/packages/ui/src/tokens.css
+++ b/packages/ui/src/tokens.css
@@ -60,6 +60,15 @@
   --font-2xl: 1.875rem;
   --font-display: 2.5rem;
   --font-mono: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Consolas, monospace;
+
+  /* Motion system (shared) — one set of curves & durations so every
+     transition across the app feels like it belongs to the same product. */
+  --ease-out: cubic-bezier(0.25, 1, 0.5, 1);
+  --ease-out-expo: cubic-bezier(0.16, 1, 0.3, 1);
+  --ease-spring: cubic-bezier(0.34, 1.4, 0.64, 1);
+  --dur-fast: 0.15s;
+  --dur-base: 0.25s;
+  --dur-slow: 0.4s;
 }
 
 /* --- Light Mode --- */

--- a/web-ui/src/App.svelte
+++ b/web-ui/src/App.svelte
@@ -9,6 +9,8 @@
   import SidePanel from "./components/SidePanel.svelte";
   import Sparkline from "@amigo/ui/components/Sparkline.svelte";
   import Toasts from "./components/Toasts.svelte";
+  import CommandPalette from "./components/CommandPalette.svelte";
+  import MobileNav from "./components/MobileNav.svelte";
   import {
     addDownload,
     connectWebSocket,
@@ -26,8 +28,8 @@
     crashReport,
     currentPage,
     downloads,
+    downloadsLoaded,
     features,
-    getNeonLabel,
     neonIntensity,
     openAddPanel,
     palette,
@@ -45,7 +47,6 @@
     wsConnected,
     attachRouterPopstateListener,
     type CaptchaChallenge,
-    type ColorPalette,
     type Page,
     type ProtocolFilter,
   } from "./lib/stores";
@@ -92,8 +93,7 @@
 
   let showFeedback = $derived($showFeedbackDialog);
   let showShortcuts = $state(false);
-  let showPalette = $state(false);
-  let mobileMenuOpen = $state(false);
+  let showCommandPalette = $state(false);
   let pageKey = $state(0);
 
   // Bandwidth limit
@@ -118,15 +118,6 @@
 
   const mgmtNavItems: { id: Page; label: string; icon: string }[] = [
     { id: "settings", label: "Settings", icon: "gear" },
-  ];
-
-  const paletteOptions: { id: ColorPalette; label: string; color: string }[] = [
-    { id: "blue", label: "Blue", color: "#3b82f6" },
-    { id: "teal", label: "Teal", color: "#14b8a6" },
-    { id: "indigo", label: "Indigo", color: "#6366f1" },
-    { id: "amber", label: "Amber", color: "#f59e0b" },
-    { id: "violet", label: "Violet", color: "#8b5cf6" },
-    { id: "rose", label: "Rose", color: "#f43f5e" },
   ];
 
   const protocolOptions: { value: ProtocolFilter; label: string }[] = [
@@ -253,6 +244,7 @@
         getConfig(),
       ]);
       downloads.set(dl);
+      downloadsLoaded.set(true);
       stats.set(st);
       pushSpeedSample(st.speed_bytes_per_sec ?? 0);
       if (cfg) {
@@ -296,17 +288,26 @@
 
   function navigate(page: Page) {
     currentPage.set(page);
-    mobileMenuOpen = false;
     pageKey++;
   }
 
   // Single global keyboard handler
   function handleKeydown(e: KeyboardEvent) {
+    // Command palette — the power-user entry point.
+    if ((e.ctrlKey || e.metaKey) && (e.key === "k" || e.key === "K")) {
+      e.preventDefault();
+      showCommandPalette = !showCommandPalette;
+      return;
+    }
     if ((e.ctrlKey || e.metaKey) && e.key === "n") {
       e.preventDefault();
       openAddPanel();
     }
     if (e.key === "Escape") {
+      if (showCommandPalette) {
+        showCommandPalette = false;
+        return;
+      }
       if ($sidePanelMode) {
         closeSidePanel();
         return;
@@ -319,11 +320,6 @@
         showFeedbackDialog.set(false);
         return;
       }
-      if (showPalette) {
-        showPalette = false;
-        return;
-      }
-      mobileMenuOpen = false;
     }
     if (e.key === "?" && !e.ctrlKey && !e.metaKey && !e.altKey) {
       showShortcuts = !showShortcuts;
@@ -334,6 +330,7 @@
       !$sidePanelMode &&
       !showFeedback &&
       !showShortcuts &&
+      !showCommandPalette &&
       !e.ctrlKey &&
       !e.metaKey &&
       !e.altKey
@@ -345,10 +342,7 @@
     }
   }
 
-  let pageTitle = $derived(
-    $currentPage.charAt(0).toUpperCase() + $currentPage.slice(1),
-  );
-  let neonLabel = $derived(getNeonLabel($neonIntensity));
+  let pageTitle = $derived(tr($locale, `nav.${$currentPage}`));
 </script>
 
 <svelte:window onkeydown={handleKeydown} />
@@ -412,11 +406,12 @@
           onclick={() => navigate(item.id)}
           class="nav-link w-full"
           class:active={$currentPage === item.id}
-          title={$sidebarCollapsed ? item.label : undefined}
+          aria-current={$currentPage === item.id ? "page" : undefined}
+          title={$sidebarCollapsed ? tr($locale, `nav.${item.id}`) : undefined}
         >
           <Icon name={item.icon} size={18} />
           {#if !$sidebarCollapsed}
-            <span class="flex-1 text-left">{item.label}</span>
+            <span class="flex-1 text-left">{tr($locale, `nav.${item.id}`)}</span>
             <span class="text-[10px] opacity-30">{i + 1}</span>
           {/if}
         </button>
@@ -431,11 +426,12 @@
           onclick={() => navigate(item.id)}
           class="nav-link w-full"
           class:active={$currentPage === item.id}
-          title={$sidebarCollapsed ? item.label : undefined}
+          aria-current={$currentPage === item.id ? "page" : undefined}
+          title={$sidebarCollapsed ? tr($locale, `nav.${item.id}`) : undefined}
         >
           <Icon name={item.icon} size={18} />
           {#if !$sidebarCollapsed}
-            <span class="flex-1 text-left">{item.label}</span>
+            <span class="flex-1 text-left">{tr($locale, `nav.${item.id}`)}</span>
             <span class="text-[10px] opacity-30">{mainNavItems.length + i + 1}</span>
           {/if}
         </button>
@@ -514,32 +510,6 @@
     <!-- Sidebar footer -->
     <div class="px-2 py-3 border-t" style="border-color: var(--border-color)">
       {#if !$sidebarCollapsed}
-        <!-- Palette picker -->
-        {#if showPalette}
-          <div class="flex items-center gap-2 mb-3 px-2">
-            {#each paletteOptions as opt}
-              <button
-                class="color-swatch"
-                class:active={$palette === opt.id}
-                style="--swatch-color: {opt.color}; background: {opt.color}"
-                aria-label={opt.label}
-                onclick={() => { palette.set(opt.id); showPalette = false; }}
-              ></button>
-            {/each}
-          </div>
-        {/if}
-
-        <!-- Neon intensity slider -->
-        <div class="neon-slider mb-2 px-2">
-          <Icon name="bolt" size={14} />
-          <input
-            type="range" min="0" max="1" step="0.25" value={$neonIntensity}
-            oninput={(e) => neonIntensity.set(parseFloat((e.target as HTMLInputElement).value))}
-            aria-label="Neon intensity"
-          />
-          <span class="neon-slider-label">{neonLabel}</span>
-        </div>
-
         <!-- Controls row -->
         <div class="flex items-center justify-between px-2">
           <!-- Connection status -->
@@ -547,12 +517,21 @@
             <span
               class="w-2 h-2 rounded-full shrink-0"
               style="background: {$wsConnected ? 'var(--status-online)' : 'var(--status-error)'}; box-shadow: 0 0 4px {$wsConnected ? 'var(--status-online)' : 'var(--status-error)'}"
+              aria-hidden="true"
             ></span>
-            <span class="text-[10px]" style="color: var(--text-secondary); font-family: var(--font-mono)">v0.1</span>
+            <span class="text-[10px]" style="color: var(--text-secondary); font-family: var(--font-mono)">
+              {tr($locale, $wsConnected ? "connection.online" : "connection.offline")}
+            </span>
           </div>
           <div class="flex items-center gap-1">
-            <button class="icon-btn p-1.5 rounded-lg" style="color: var(--text-secondary)" aria-label="Color theme" onclick={() => (showPalette = !showPalette)}>
-              <div class="w-4 h-4 rounded-full" style="background: var(--neon-primary); box-shadow: var(--neon-glow-sm)"></div>
+            <button
+              onclick={() => (showCommandPalette = true)}
+              class="icon-btn flex items-center gap-1 px-1.5 py-1 rounded-lg"
+              style="color: var(--text-secondary)"
+              aria-label={tr($locale, "cmd.hint_open")}
+            >
+              <Icon name="search" size={14} />
+              <kbd class="text-[10px]" style="font-family: var(--font-mono)">⌘K</kbd>
             </button>
             <button onclick={() => theme.toggle()} class="icon-btn p-1.5 rounded-lg" style="color: var(--text-secondary)" aria-label={$theme === "dark" ? "Switch to Light mode" : "Switch to Dark mode"}>
               <Icon name={$theme === "light" ? "moon" : "sun"} size={16} />
@@ -573,71 +552,6 @@
     </div>
   </aside>
 
-  <!-- Mobile sidebar overlay -->
-  {#if mobileMenuOpen}
-    <div class="fixed inset-0 z-50 md:hidden">
-      <button
-        class="absolute inset-0 bg-black/60"
-        onclick={() => (mobileMenuOpen = false)}
-        aria-label="Close navigation"
-      ></button>
-      <aside
-        class="relative w-64 h-full flex flex-col neon-top-line"
-        style="background: var(--bg-surface)"
-        aria-label="Navigation"
-      >
-        <div
-          class="sidebar-logo flex items-center gap-3 px-4 py-4 border-b"
-          style="border-color: var(--border-color)"
-        >
-          <img
-            src="/amigo-logo.png"
-            alt="amigo-downloader"
-            width="40"
-            height="40"
-          />
-          <h1 class="font-bold text-base" style="color: var(--neon-primary)">
-            AMIGO
-          </h1>
-        </div>
-        <button
-          class="search-trigger"
-          onclick={() => {
-            openAddPanel();
-            mobileMenuOpen = false;
-          }}
-        >
-          <Icon name="plus" size={16} />
-          <span>Add Download...</span>
-        </button>
-        <nav class="flex-1 px-2 py-1">
-          {#each mainNavItems as item, i}
-            <button
-              onclick={() => navigate(item.id)}
-              class="nav-link w-full"
-              class:active={$currentPage === item.id}
-            >
-              <Icon name={item.icon} size={18} />
-              <span class="flex-1 text-left">{item.label}</span>
-              <span class="text-[10px] opacity-30">{i + 1}</span>
-            </button>
-          {/each}
-          <div class="nav-section-label">Management</div>
-          {#each mgmtNavItems as item, i}
-            <button
-              onclick={() => navigate(item.id)}
-              class="nav-link w-full"
-              class:active={$currentPage === item.id}
-            >
-              <Icon name={item.icon} size={18} />
-              <span class="flex-1 text-left">{item.label}</span>
-            </button>
-          {/each}
-        </nav>
-      </aside>
-    </div>
-  {/if}
-
   <!-- Main content -->
   <main
     id="main-content"
@@ -647,19 +561,14 @@
   >
     <!-- Header -->
     <header
-      class="flex items-center justify-between px-8 py-3 border-b"
+      class="flex items-center justify-between gap-3 px-4 md:px-8 py-3 border-b"
       style="border-color: var(--border-color)"
     >
-      <div class="flex items-center gap-3">
-        <button
-          class="md:hidden p-1"
-          onclick={() => (mobileMenuOpen = !mobileMenuOpen)}
-          aria-label="Toggle navigation"
-        >
-          <Icon name="menu" size={20} class="text-[var(--text-secondary)]" />
-        </button>
+      <div class="flex items-center gap-3 min-w-0">
+        <!-- Mobile brand (no sidebar on small screens) -->
+        <img src="/amigo-logo.png" alt="" width="28" height="28" class="md:hidden shrink-0 rounded-full" />
         <h2
-          class="text-xl font-semibold neon-flicker-text"
+          class="text-lg md:text-xl font-semibold neon-flicker-text truncate"
           style="color: var(--text-primary)"
         >
           {pageTitle}
@@ -670,7 +579,7 @@
           <div
             role="radiogroup"
             aria-label="Protocol filter"
-            class="flex rounded-lg ml-3 overflow-hidden"
+            class="hidden sm:flex rounded-lg ml-1 overflow-hidden shrink-0"
             style="background: var(--bg-surface-2); border: 1px solid var(--border-color)"
           >
             {#each protocolOptions as opt}
@@ -690,19 +599,61 @@
           </div>
         {/if}
       </div>
-      <button
-        onclick={() => openAddPanel()}
-        class="icon-btn p-2 rounded-lg min-w-[44px] min-h-[44px] flex items-center justify-center"
-        style="color: var(--text-secondary)"
-        aria-label="Add download"
-      >
-        <Icon name="plus" size={20} />
-      </button>
+
+      <!-- Global status bar — status at a glance from any page -->
+      <div class="flex items-center gap-3 md:gap-5 shrink-0">
+        <div class="hidden md:flex items-center gap-5" aria-label="Download status">
+          <div class="flex items-center gap-2">
+            <span class="stat-label">{tr($locale, "sidebar.speed")}</span>
+            <span class="text-xs tabular-nums" style="color: var(--neon-primary); font-family: var(--font-mono)">
+              {formatSpeed($stats.speed_bytes_per_sec)}
+            </span>
+            {#if $speedHistory.length > 1}
+              <span class="hidden xl:block"><Sparkline values={$speedHistory} width={72} height={20} /></span>
+            {/if}
+          </div>
+          <div class="flex items-center gap-1.5" title={tr($locale, "sidebar.active")}>
+            {#if $stats.active_downloads > 0}
+              <ProgressRing progress={overallProgress()} size={18} stroke={2} active={true} />
+            {/if}
+            <span class="text-xs tabular-nums" style="color: var(--text-primary); font-family: var(--font-mono)">{$stats.active_downloads}</span>
+            <span class="stat-label">{tr($locale, "sidebar.active")}</span>
+          </div>
+          <div class="hidden lg:flex items-center gap-1.5" title={tr($locale, "sidebar.queued")}>
+            <span class="text-xs tabular-nums" style="color: var(--text-primary); font-family: var(--font-mono)">{$stats.queued}</span>
+            <span class="stat-label">{tr($locale, "sidebar.queued")}</span>
+          </div>
+          <div class="hidden lg:flex items-center gap-1.5" title={tr($locale, "sidebar.done")}>
+            <span class="text-xs tabular-nums" style="color: var(--status-online); font-family: var(--font-mono)">{$stats.completed}</span>
+            <span class="stat-label">{tr($locale, "sidebar.done")}</span>
+          </div>
+        </div>
+
+        <!-- Command palette trigger -->
+        <button
+          onclick={() => (showCommandPalette = true)}
+          class="hidden sm:flex items-center gap-2 px-2.5 py-1.5 rounded-lg text-xs"
+          style="background: var(--bg-surface-2); border: 1px solid var(--border-color); color: var(--text-secondary)"
+          aria-label={tr($locale, "cmd.hint_open")}
+        >
+          <Icon name="search" size={14} />
+          <kbd style="font-family: var(--font-mono)">⌘K</kbd>
+        </button>
+
+        <button
+          onclick={() => openAddPanel()}
+          class="hidden md:flex icon-btn p-2 rounded-lg min-w-[44px] min-h-[44px] items-center justify-center"
+          style="color: var(--text-secondary)"
+          aria-label={tr($locale, "cmd.add_download")}
+        >
+          <Icon name="plus" size={20} />
+        </button>
+      </div>
     </header>
 
     <!-- Page content -->
     <div class="flex flex-1 min-h-0">
-      <div class="flex-1 overflow-y-auto p-8 md:p-8 max-md:p-4">
+      <div class="flex-1 overflow-y-auto p-8 md:p-8 max-md:p-4 max-md:pb-28">
         {#key pageKey}
           <div class="page-enter">
             <svelte:boundary onerror={(e) => console.error("Page error:", e)}>
@@ -724,9 +675,19 @@
       <SidePanel />
     </div>
   </main>
+
+  <!-- Mobile bottom navigation + Add FAB -->
+  <MobileNav current={$currentPage} onnavigate={navigate} onadd={() => openAddPanel()} />
 </div>
 
 <!-- Dialogs -->
+{#if showCommandPalette}
+  <CommandPalette
+    onclose={() => (showCommandPalette = false)}
+    onshortcuts={() => (showShortcuts = true)}
+  />
+{/if}
+
 {#if showShortcuts}
   <ShortcutsDialog onclose={() => (showShortcuts = false)} />
 {/if}

--- a/web-ui/src/App.svelte
+++ b/web-ui/src/App.svelte
@@ -251,7 +251,6 @@
         getConfig(),
       ]);
       downloads.set(dl);
-      downloadsLoaded.set(true);
       stats.set(st);
       pushSpeedSample(st.speed_bytes_per_sec ?? 0);
       if (cfg) {
@@ -265,7 +264,12 @@
         }
       }
     } catch {
-      // Server offline
+      // Server offline — fall through.
+    } finally {
+      // Flip after the first attempt (success or failure) so the Downloads
+      // page can drop skeletons and show its empty/offline state instead of
+      // spinning forever when the server is unreachable.
+      downloadsLoaded.set(true);
     }
   }
 

--- a/web-ui/src/components/AddPanel.svelte
+++ b/web-ui/src/components/AddPanel.svelte
@@ -2,26 +2,34 @@
   import { addDownload, addBatch } from "../lib/api";
   import { closeSidePanel } from "../lib/stores";
   import { addToast } from "../lib/toast";
+  import { locale, tr } from "../lib/i18n";
   import Icon from "@amigo/ui/components/Icon.svelte";
 
   let urlInput = $state("");
   let loading = $state(false);
   let activeTab = $state<"url" | "file">("url");
 
+  const URL_RE = /^(https?|magnet|ftp):/i;
+
+  let lines = $derived(urlInput.split("\n").map((u) => u.trim()).filter((u) => u.length > 0));
+  let validLinks = $derived(lines.filter((u) => URL_RE.test(u)));
+  let invalidCount = $derived(lines.length - validLinks.length);
+  let canSubmit = $derived(validLinks.length > 0 && !loading);
+
   async function handleSubmit() {
-    if (!urlInput.trim()) return;
+    if (validLinks.length === 0) return;
     loading = true;
-    const urls = urlInput.split("\n").map((u) => u.trim()).filter((u) => u.length > 0);
     try {
-      if (urls.length === 1) {
-        await addDownload(urls[0]);
+      if (validLinks.length === 1) {
+        await addDownload(validLinks[0]);
+        addToast("success", tr($locale, "add.added"));
       } else {
-        await addBatch(urls);
+        await addBatch(validLinks);
+        addToast("success", tr($locale, "add.added_many", { count: validLinks.length }));
       }
-      addToast("success", "Download added");
       closeSidePanel();
     } catch (e: any) {
-      addToast("error", "Failed to add download", e?.message);
+      addToast("error", tr($locale, "add.failed"), e?.message);
     } finally {
       loading = false;
     }
@@ -47,10 +55,10 @@
         loading = false;
         return;
       }
-      addToast("success", "File imported");
+      addToast("success", tr($locale, "add.file_imported"));
       closeSidePanel();
     } catch (e: any) {
-      addToast("error", "Failed to import file", e?.message);
+      addToast("error", tr($locale, "add.file_failed"), e?.message);
     } finally {
       loading = false;
     }
@@ -63,24 +71,28 @@
 
 <div class="p-4 space-y-4">
   <!-- Tabs -->
-  <div class="flex gap-1 p-1 rounded-lg" style="background: var(--bg-surface-2)">
+  <div class="flex gap-1 p-1 rounded-lg" style="background: var(--bg-surface-2)" role="tablist">
     <button
+      role="tab"
+      aria-selected={activeTab === "url"}
       onclick={() => (activeTab = "url")}
       class="flex-1 py-2 rounded-md text-sm font-medium transition-colors"
       style={activeTab === "url"
         ? "background: var(--bg-surface); color: var(--neon-primary)"
         : "color: var(--text-secondary)"}
     >
-      URL / Links
+      {tr($locale, "add.tab_url")}
     </button>
     <button
+      role="tab"
+      aria-selected={activeTab === "file"}
       onclick={() => (activeTab = "file")}
       class="flex-1 py-2 rounded-md text-sm font-medium transition-colors"
       style={activeTab === "file"
         ? "background: var(--bg-surface); color: var(--neon-primary)"
         : "color: var(--text-secondary)"}
     >
-      File (NZB / DLC)
+      {tr($locale, "add.tab_file")}
     </button>
   </div>
 
@@ -88,21 +100,36 @@
     <textarea
       bind:value={urlInput}
       onkeydown={handleKeydown}
-      placeholder="Paste URL(s) here — one per line"
+      placeholder={tr($locale, "add.placeholder")}
       rows="6"
       class="w-full rounded-lg px-4 py-3 text-sm resize-none"
       style="font-family: var(--font-mono);background: var(--bg-surface-2); border: 1px solid var(--border-color); color: var(--text-primary)"
     ></textarea>
-    <p class="text-xs" style="color: var(--text-secondary)">
-      Ctrl+Enter to submit. Multiple URLs supported (one per line).
-    </p>
+
+    <!-- Live link detection / validation -->
+    <div class="flex items-center justify-between text-xs min-h-[1rem]">
+      <span style="color: var(--text-secondary)">{tr($locale, "add.hint")}</span>
+      {#if validLinks.length > 0}
+        <span class="font-semibold tabular-nums" style="color: var(--neon-primary)">
+          {validLinks.length === 1
+            ? tr($locale, "add.links_one")
+            : tr($locale, "add.links_many", { count: validLinks.length })}
+        </span>
+      {/if}
+    </div>
+    {#if invalidCount > 0}
+      <p class="text-xs" style="color: var(--neon-warning)">
+        {tr($locale, "add.links_invalid", { count: invalidCount })}
+      </p>
+    {/if}
+
     <button
       onclick={handleSubmit}
-      disabled={loading || !urlInput.trim()}
-      class="w-full py-2.5 rounded-lg font-semibold text-sm transition-colors disabled:opacity-40"
+      disabled={!canSubmit}
+      class="action-btn w-full py-2.5 rounded-lg font-semibold text-sm disabled:opacity-40"
       style="background: var(--neon-primary); color: var(--bg-deep)"
     >
-      {loading ? "Adding..." : "Add Download"}
+      {loading ? tr($locale, "common.adding") : tr($locale, "add.submit")}
     </button>
   {:else}
     <label
@@ -110,8 +137,8 @@
       style="border-color: var(--border-color)"
     >
       <Icon name="upload" size={24} />
-      <p class="text-sm font-medium mt-3" style="color: var(--text-primary)">Drop file here or click to browse</p>
-      <p class="text-xs mt-1" style="color: var(--text-secondary)">NZB, DLC, or text file with URLs</p>
+      <p class="text-sm font-medium mt-3" style="color: var(--text-primary)">{tr($locale, "add.drop_hint")}</p>
+      <p class="text-xs mt-1" style="color: var(--text-secondary)">{tr($locale, "add.file_types")}</p>
       <input type="file" accept=".nzb,.dlc,.txt" class="hidden" onchange={handleFileUpload} />
     </label>
   {/if}

--- a/web-ui/src/components/AddPanel.svelte
+++ b/web-ui/src/components/AddPanel.svelte
@@ -74,7 +74,9 @@
   <div class="flex gap-1 p-1 rounded-lg" style="background: var(--bg-surface-2)" role="tablist">
     <button
       role="tab"
+      id="add-tab-url"
       aria-selected={activeTab === "url"}
+      aria-controls="add-panel-url"
       onclick={() => (activeTab = "url")}
       class="flex-1 py-2 rounded-md text-sm font-medium transition-colors"
       style={activeTab === "url"
@@ -85,7 +87,9 @@
     </button>
     <button
       role="tab"
+      id="add-tab-file"
       aria-selected={activeTab === "file"}
+      aria-controls="add-panel-file"
       onclick={() => (activeTab = "file")}
       class="flex-1 py-2 rounded-md text-sm font-medium transition-colors"
       style={activeTab === "file"
@@ -97,6 +101,7 @@
   </div>
 
   {#if activeTab === "url"}
+    <div role="tabpanel" id="add-panel-url" aria-labelledby="add-tab-url" tabindex="0" class="space-y-4 outline-none">
     <textarea
       bind:value={urlInput}
       onkeydown={handleKeydown}
@@ -131,7 +136,9 @@
     >
       {loading ? tr($locale, "common.adding") : tr($locale, "add.submit")}
     </button>
+    </div>
   {:else}
+    <div role="tabpanel" id="add-panel-file" aria-labelledby="add-tab-file" tabindex="0" class="outline-none">
     <label
       class="flex flex-col items-center justify-center border-2 border-dashed rounded-xl py-10 cursor-pointer transition-colors"
       style="border-color: var(--border-color)"
@@ -141,5 +148,6 @@
       <p class="text-xs mt-1" style="color: var(--text-secondary)">{tr($locale, "add.file_types")}</p>
       <input type="file" accept=".nzb,.dlc,.txt" class="hidden" onchange={handleFileUpload} />
     </label>
+    </div>
   {/if}
 </div>

--- a/web-ui/src/components/CaptchaDialog.svelte
+++ b/web-ui/src/components/CaptchaDialog.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
   import { onMount } from "svelte";
   import { addToast } from "../lib/toast";
-  import Icon from "@amigo/ui/components/Icon.svelte";
+  import { locale, tr } from "../lib/i18n";
+  import { focusTrap } from "../lib/focusTrap";
+  import { scaleFade, dur } from "../lib/motion";
 
   let { captcha, onclose }: {
     captcha: {
@@ -26,7 +28,7 @@
       elapsed++;
       if (elapsed >= TIMEOUT) {
         if (timerRef) clearInterval(timerRef);
-        addToast("error", "Captcha timed out");
+        addToast("error", tr($locale, "captcha.expired"));
         onclose();
       }
     }, 1000);
@@ -72,12 +74,12 @@
         body: JSON.stringify({ answer: answer.trim() }),
       });
       if (res.ok) {
-        addToast("success", "Captcha solved");
+        addToast("success", tr($locale, "captcha.solved"));
       } else {
-        addToast("error", "Failed to submit captcha");
+        addToast("error", tr($locale, "captcha.failed"));
       }
     } catch {
-      addToast("error", "Failed to submit captcha");
+      addToast("error", tr($locale, "captcha.failed"));
     }
     if (timerRef) clearInterval(timerRef);
     onclose();
@@ -99,23 +101,24 @@
   }
 </script>
 
-<!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
-  class="fixed inset-0 z-[100] flex items-center justify-center bg-black/70"
-  onkeydown={handleKeydown}
+  class="fixed inset-0 z-[100] flex items-center justify-center bg-black/70 p-4"
 >
   <!-- Dialog (audit C2) -->
   <div
+    use:focusTrap
     role="dialog"
     aria-modal="true"
     aria-labelledby="captcha-title"
-    class="w-full max-w-md mx-4 rounded-2xl shadow-2xl overflow-hidden"
-    style="background: var(--bg-surface); border: 1px solid var(--border-color)"
+    class="w-full max-w-md rounded-2xl shadow-2xl overflow-hidden neon-card"
+    style="background: var(--bg-surface)"
+    onkeydown={handleKeydown}
+    transition:scaleFade={{ duration: dur(180), y: 8 }}
   >
     <!-- Header -->
     <div class="flex items-center justify-between px-5 py-3 border-b" style="border-color: var(--border-color)">
       <div>
-        <h3 id="captcha-title" class="font-bold text-base" style="color: var(--text-primary)">Captcha Required</h3>
+        <h3 id="captcha-title" class="font-bold text-base" style="color: var(--text-primary)">{tr($locale, "captcha.title")}</h3>
         <p class="text-xs mt-0.5" style="color: var(--text-secondary)">
           {captcha.plugin_id} &middot; {captcha.captcha_type}
         </p>
@@ -152,10 +155,9 @@
       <input
         type="text"
         bind:value={answer}
-        placeholder="Enter captcha text..."
+        placeholder={tr($locale, "captcha.enter")}
         class="w-full px-4 py-3 rounded-lg text-center text-lg tracking-wider border"
         style="font-family: var(--font-mono);background: var(--bg-surface-2); border-color: var(--border-color); color: var(--text-primary)"
-        autofocus
         disabled={submitting}
       />
 
@@ -167,7 +169,7 @@
           style="border-color: var(--border-color); color: var(--text-secondary)"
           disabled={submitting}
         >
-          Skip
+          {tr($locale, "captcha.skip")}
         </button>
         <button
           onclick={submitAnswer}
@@ -175,7 +177,7 @@
           style="background: var(--neon-primary); color: var(--bg-deep)"
           disabled={!answer.trim() || submitting}
         >
-          {submitting ? "Submitting..." : "Solve"}
+          {submitting ? "…" : tr($locale, "captcha.solve")}
         </button>
       </div>
     </div>

--- a/web-ui/src/components/CommandPalette.svelte
+++ b/web-ui/src/components/CommandPalette.svelte
@@ -30,12 +30,12 @@
     { id: "rose", label: "Rose", color: "#f43f5e" },
   ];
 
-  const intensities: { value: number; label: string }[] = [
-    { value: 0, label: "Off" },
-    { value: 0.25, label: "Low" },
-    { value: 0.5, label: "Mid" },
-    { value: 0.75, label: "High" },
-    { value: 1, label: "Full" },
+  const intensities: { value: number; key: string }[] = [
+    { value: 0, key: "intensity.off" },
+    { value: 0.25, key: "intensity.low" },
+    { value: 0.5, key: "intensity.mid" },
+    { value: 0.75, key: "intensity.high" },
+    { value: 1, key: "intensity.full" },
   ];
 
   const pages: { id: Page; key: string; icon: string }[] = [
@@ -91,14 +91,17 @@
       keywords: `palette color ${p.id} ${p.label} accent`,
       run: () => go(() => palette.set(p.id)),
     })),
-    ...intensities.map((it) => ({
-      id: `intensity-${it.value}`,
-      group: tr($locale, "cmd.group_appearance"),
-      label: tr($locale, "cmd.set_intensity", { name: it.label }),
-      icon: "bolt",
-      keywords: `neon intensity glow ${it.label}`,
-      run: () => go(() => neonIntensity.set(it.value)),
-    })),
+    ...intensities.map((it) => {
+      const name = tr($locale, it.key);
+      return {
+        id: `intensity-${it.value}`,
+        group: tr($locale, "cmd.group_appearance"),
+        label: tr($locale, "cmd.set_intensity", { name }),
+        icon: "bolt",
+        keywords: `neon intensity glow ${name}`,
+        run: () => go(() => neonIntensity.set(it.value)),
+      };
+    }),
   ]);
 
   let query = $state("");

--- a/web-ui/src/components/CommandPalette.svelte
+++ b/web-ui/src/components/CommandPalette.svelte
@@ -1,0 +1,234 @@
+<script lang="ts">
+  import { fade } from "svelte/transition";
+  import {
+    currentPage, openAddPanel, theme, palette, neonIntensity,
+    type Page, type ColorPalette,
+  } from "../lib/stores";
+  import { locale, tr } from "../lib/i18n";
+  import { focusTrap } from "../lib/focusTrap";
+  import { scaleFade, dur } from "../lib/motion";
+  import Icon from "@amigo/ui/components/Icon.svelte";
+
+  let { onclose, onshortcuts }: { onclose: () => void; onshortcuts: () => void } = $props();
+
+  interface Command {
+    id: string;
+    group: string;
+    label: string;
+    icon?: string;
+    swatch?: string;
+    keywords: string;
+    run: () => void;
+  }
+
+  const palettes: { id: ColorPalette; label: string; color: string }[] = [
+    { id: "blue", label: "Blue", color: "#3b82f6" },
+    { id: "teal", label: "Teal", color: "#14b8a6" },
+    { id: "indigo", label: "Indigo", color: "#6366f1" },
+    { id: "amber", label: "Amber", color: "#f59e0b" },
+    { id: "violet", label: "Violet", color: "#8b5cf6" },
+    { id: "rose", label: "Rose", color: "#f43f5e" },
+  ];
+
+  const intensities: { value: number; label: string }[] = [
+    { value: 0, label: "Off" },
+    { value: 0.25, label: "Low" },
+    { value: 0.5, label: "Mid" },
+    { value: 0.75, label: "High" },
+    { value: 1, label: "Full" },
+  ];
+
+  const pages: { id: Page; key: string; icon: string }[] = [
+    { id: "downloads", key: "nav.downloads", icon: "arrow-down" },
+    { id: "plugins", key: "nav.plugins", icon: "puzzle" },
+    { id: "history", key: "nav.history", icon: "clock" },
+    { id: "settings", key: "nav.settings", icon: "gear" },
+  ];
+
+  function go(action: () => void) {
+    action();
+    onclose();
+  }
+
+  let commands = $derived<Command[]>([
+    ...pages.map((p) => ({
+      id: `nav-${p.id}`,
+      group: tr($locale, "cmd.group_navigate"),
+      label: tr($locale, p.key),
+      icon: p.icon,
+      keywords: `${p.id} ${tr($locale, p.key)}`,
+      run: () => go(() => currentPage.set(p.id)),
+    })),
+    {
+      id: "add",
+      group: tr($locale, "cmd.group_actions"),
+      label: tr($locale, "cmd.add_download"),
+      icon: "plus",
+      keywords: "add download new url link",
+      run: () => go(() => openAddPanel()),
+    },
+    {
+      id: "shortcuts",
+      group: tr($locale, "cmd.group_actions"),
+      label: tr($locale, "cmd.show_shortcuts"),
+      icon: "info",
+      keywords: "keyboard shortcuts help keys",
+      run: () => go(() => onshortcuts()),
+    },
+    {
+      id: "theme",
+      group: tr($locale, "cmd.group_appearance"),
+      label: tr($locale, "cmd.toggle_theme"),
+      icon: "sun",
+      keywords: "theme dark light mode appearance",
+      run: () => go(() => theme.toggle()),
+    },
+    ...palettes.map((p) => ({
+      id: `palette-${p.id}`,
+      group: tr($locale, "cmd.group_appearance"),
+      label: tr($locale, "cmd.set_palette", { name: p.label }),
+      swatch: p.color,
+      keywords: `palette color ${p.id} ${p.label} accent`,
+      run: () => go(() => palette.set(p.id)),
+    })),
+    ...intensities.map((it) => ({
+      id: `intensity-${it.value}`,
+      group: tr($locale, "cmd.group_appearance"),
+      label: tr($locale, "cmd.set_intensity", { name: it.label }),
+      icon: "bolt",
+      keywords: `neon intensity glow ${it.label}`,
+      run: () => go(() => neonIntensity.set(it.value)),
+    })),
+  ]);
+
+  let query = $state("");
+  let selected = $state(0);
+
+  // Subsequence fuzzy match: every char of the query appears in order.
+  function matches(cmd: Command, q: string): boolean {
+    if (!q) return true;
+    const hay = `${cmd.label} ${cmd.keywords}`.toLowerCase();
+    let i = 0;
+    for (const ch of q.toLowerCase()) {
+      i = hay.indexOf(ch, i);
+      if (i === -1) return false;
+      i++;
+    }
+    return true;
+  }
+
+  let results = $derived(commands.filter((c) => matches(c, query.trim())));
+
+  // Group results, preserving group order of first appearance.
+  let grouped = $derived.by(() => {
+    const order: string[] = [];
+    const map = new Map<string, Command[]>();
+    for (const c of results) {
+      if (!map.has(c.group)) { map.set(c.group, []); order.push(c.group); }
+      map.get(c.group)!.push(c);
+    }
+    return order.map((g) => ({ group: g, items: map.get(g)! }));
+  });
+
+  // Flat list mirrors render order so arrow keys land on the right command.
+  let flat = $derived(grouped.flatMap((g) => g.items));
+
+  $effect(() => {
+    query;
+    selected = 0;
+  });
+
+  function clampSelect(next: number) {
+    const n = flat.length;
+    if (n === 0) return;
+    selected = ((next % n) + n) % n;
+    document.getElementById(`cmd-${selected}`)?.scrollIntoView({ block: "nearest" });
+  }
+
+  function onKeydown(e: KeyboardEvent) {
+    if (e.key === "Escape") { e.preventDefault(); e.stopPropagation(); onclose(); }
+    else if (e.key === "ArrowDown") { e.preventDefault(); clampSelect(selected + 1); }
+    else if (e.key === "ArrowUp") { e.preventDefault(); clampSelect(selected - 1); }
+    else if (e.key === "Enter") { e.preventDefault(); flat[selected]?.run(); }
+  }
+</script>
+
+<div class="fixed inset-0 z-[110] flex items-start justify-center p-4 pt-[12vh]">
+  <button
+    class="fixed inset-0 bg-black/60"
+    style="backdrop-filter: blur(2px)"
+    onclick={onclose}
+    aria-label={tr($locale, "common.close")}
+    transition:fade={{ duration: dur(150) }}
+  ></button>
+
+  <div
+    use:focusTrap
+    role="dialog"
+    aria-modal="true"
+    aria-label={tr($locale, "cmd.hint_open")}
+    class="relative z-10 w-full max-w-xl rounded-2xl overflow-hidden neon-card"
+    style="background: var(--bg-surface)"
+    transition:scaleFade={{ duration: dur(180), y: 8 }}
+    onkeydown={onKeydown}
+  >
+    <!-- Search -->
+    <div class="flex items-center gap-3 px-4 py-3 border-b" style="border-color: var(--border-color)">
+      <Icon name="search" size={18} />
+      <input
+        type="text"
+        bind:value={query}
+        placeholder={tr($locale, "cmd.placeholder")}
+        class="flex-1 bg-transparent text-sm outline-none"
+        style="color: var(--text-primary)"
+        aria-label={tr($locale, "cmd.placeholder")}
+        role="combobox"
+        aria-expanded="true"
+        aria-controls="cmd-list"
+      />
+      <kbd
+        class="px-1.5 py-0.5 rounded text-[10px] font-semibold shrink-0"
+        style="font-family: var(--font-mono); background: var(--bg-deep); border: 1px solid var(--border-color); color: var(--text-secondary)"
+      >ESC</kbd>
+    </div>
+
+    <!-- Results -->
+    <div id="cmd-list" role="listbox" class="max-h-[50vh] overflow-y-auto py-2">
+      {#if flat.length === 0}
+        <p class="px-4 py-8 text-center text-sm" style="color: var(--text-secondary)">
+          {tr($locale, "cmd.no_results")}
+        </p>
+      {:else}
+        {#each grouped as section}
+          <div class="px-3 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-wider" style="color: var(--text-secondary)">
+            {section.group}
+          </div>
+          {#each section.items as cmd}
+            {@const idx = flat.indexOf(cmd)}
+            <button
+              id="cmd-{idx}"
+              role="option"
+              aria-selected={selected === idx}
+              onclick={cmd.run}
+              onmousemove={() => (selected = idx)}
+              class="w-full flex items-center gap-3 px-3 py-2 mx-1 rounded-lg text-left text-sm"
+              style={selected === idx
+                ? "background: color-mix(in srgb, var(--neon-primary) 14%, transparent); color: var(--neon-primary)"
+                : "color: var(--text-primary)"}
+            >
+              {#if cmd.swatch}
+                <span class="w-4 h-4 rounded-full shrink-0" style="background: {cmd.swatch}"></span>
+              {:else if cmd.icon}
+                <Icon name={cmd.icon} size={16} />
+              {/if}
+              <span class="flex-1 truncate">{cmd.label}</span>
+              {#if selected === idx}
+                <kbd class="text-[10px] opacity-60" style="font-family: var(--font-mono)">↵</kbd>
+              {/if}
+            </button>
+          {/each}
+        {/each}
+      {/if}
+    </div>
+  </div>
+</div>

--- a/web-ui/src/components/CommandPalette.svelte
+++ b/web-ui/src/components/CommandPalette.svelte
@@ -167,6 +167,7 @@
     role="dialog"
     aria-modal="true"
     aria-label={tr($locale, "cmd.hint_open")}
+    tabindex="-1"
     class="relative z-10 w-full max-w-xl rounded-2xl overflow-hidden neon-card"
     style="background: var(--bg-surface)"
     transition:scaleFade={{ duration: dur(180), y: 8 }}

--- a/web-ui/src/components/DownloadCard.svelte
+++ b/web-ui/src/components/DownloadCard.svelte
@@ -3,6 +3,7 @@
   import { pauseDownload, resumeDownload, retryDownload, deleteDownload, formatBytes, formatSpeed } from "../lib/api";
   import { openDetailPanel, selectedDownloadId, selectedIds, toggleSelection, crashReport } from "../lib/stores";
   import { addToast } from "../lib/toast";
+  import { locale, tr } from "../lib/i18n";
   import ChunkViz from "@amigo/ui/components/ChunkViz.svelte";
   import ContextMenu from "./ContextMenu.svelte";
   import Icon from "@amigo/ui/components/Icon.svelte";
@@ -32,6 +33,11 @@
     download.status === "failed" ? "var(--neon-accent)" :
     download.status === "paused" ? "var(--neon-warning)" :
     "var(--text-secondary)"
+  );
+
+  const KNOWN_STATUS = ["downloading", "completed", "failed", "paused", "queued"];
+  let statusLabel = $derived(
+    KNOWN_STATUS.includes(download.status) ? tr($locale, `status.${download.status}`) : download.status
   );
 
   let isActive = $derived(download.status === "downloading");
@@ -93,18 +99,19 @@
   }
 
   function getContextMenuItems() {
+    const lang = $locale;
     const items: { label: string; icon: string; action: () => void; color?: string }[] = [
-      { label: "Copy URL", icon: "copy", action: () => navigator.clipboard.writeText(download.url) },
-      { label: "Open in Browser", icon: "globe", action: () => window.open(download.url, "_blank") },
+      { label: tr(lang, "action.copy"), icon: "copy", action: () => navigator.clipboard.writeText(download.url) },
+      { label: tr(lang, "action.open_browser"), icon: "globe", action: () => window.open(download.url, "_blank") },
     ];
     if (download.status === "downloading") {
-      items.push({ label: "Pause", icon: "pause", action: () => pauseDownload(download.id) });
+      items.push({ label: tr(lang, "action.pause"), icon: "pause", action: () => pauseDownload(download.id) });
     } else if (download.status === "paused" || download.status === "queued") {
-      items.push({ label: "Resume", icon: "play", action: () => resumeDownload(download.id) });
+      items.push({ label: tr(lang, "action.resume"), icon: "play", action: () => resumeDownload(download.id) });
     } else if (download.status === "failed") {
-      items.push({ label: "Retry", icon: "refresh", action: () => retryDownload(download.id) });
+      items.push({ label: tr(lang, "action.retry"), icon: "refresh", action: () => retryDownload(download.id) });
     }
-    items.push({ label: "Delete", icon: "trash", action: () => deleteDownload(download.id), color: "var(--neon-accent)" });
+    items.push({ label: tr(lang, "action.delete"), icon: "trash", action: () => deleteDownload(download.id), color: "var(--neon-accent)" });
     return items;
   }
 
@@ -112,9 +119,9 @@
     e.stopPropagation();
     try {
       await navigator.clipboard.writeText(download.url);
-      addToast("info", "URL copied");
+      addToast("info", tr($locale, "action.copy_url"));
     } catch {
-      addToast("error", "Failed to copy");
+      addToast("error", tr($locale, "action.copy_failed"));
     }
   }
 </script>
@@ -179,7 +186,7 @@
         class="px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase shrink-0"
         style="color: {statusColor}; background: color-mix(in srgb, {statusColor} 10%, transparent)"
       >
-        {download.status}
+        {statusLabel}
       </span>
     </div>
 
@@ -196,13 +203,13 @@
       <div class="progress-bar mb-2">
         <div
           class="progress-bar-fill"
-          style="width: {progress}%"
+          style="width: {progress}%; transition: width var(--dur-base, 0.25s) var(--ease-out, ease)"
         ></div>
       </div>
     {/if}
 
     <div class="flex items-center justify-between text-xs" style="color: var(--text-secondary)">
-      <div class="flex gap-3" style="font-family: var(--font-mono);font-size: 11px">
+      <div class="flex gap-3 tabular-nums" style="font-family: var(--font-mono);font-size: 11px">
         <span>{formatBytes(download.bytes_downloaded)}{download.filesize ? ` / ${formatBytes(download.filesize)}` : ""}</span>
         {#if isActive && download.speed > 0}
           <span style="color: var(--neon-primary)">{formatSpeed(download.speed)}</span>
@@ -217,11 +224,11 @@
 
       <!-- Actions — 44px min touch targets (audit H1) -->
       <div class="flex gap-1 items-center" onclick={(e) => e.stopPropagation()}>
-        <button onclick={copyUrl} class="icon-btn min-w-[44px] min-h-[44px] flex items-center justify-center rounded-lg" style="color: var(--text-secondary)" aria-label="Copy URL">
+        <button onclick={copyUrl} class="icon-btn min-w-[44px] min-h-[44px] flex items-center justify-center rounded-lg" style="color: var(--text-secondary)" aria-label={tr($locale, "action.copy")}>
           <Icon name="copy" size={14} />
         </button>
         {#if download.status === "failed"}
-          <button onclick={(e: MouseEvent) => { e.stopPropagation(); retryDownload(download.id); }} class="icon-btn min-w-[44px] min-h-[44px] flex items-center justify-center rounded-lg" style="color: var(--neon-primary)" aria-label="Retry {download.filename || 'download'}">
+          <button onclick={(e: MouseEvent) => { e.stopPropagation(); retryDownload(download.id); }} class="icon-btn min-w-[44px] min-h-[44px] flex items-center justify-center rounded-lg" style="color: var(--neon-primary)" aria-label="{tr($locale, 'action.retry')} {download.filename || 'download'}">
             <Icon name="refresh" size={14} />
           </button>
           {#if download.error}
@@ -229,24 +236,24 @@
               onclick={() => crashReport.set({ download_id: download.id, error_message: download.error })}
               class="icon-btn min-w-[44px] min-h-[44px] flex items-center justify-center rounded-lg text-[10px] font-medium"
               style="color: var(--neon-warning)"
-              aria-label="Report error for {download.filename || 'download'}"
+              aria-label="{tr($locale, 'action.report')} {download.filename || 'download'}"
             >
               <Icon name="flag" size={14} />
             </button>
           {/if}
         {/if}
         {#if download.status === "downloading"}
-          <button onclick={handlePause} class="icon-btn min-w-[44px] min-h-[44px] flex items-center justify-center rounded-lg" style="color: var(--text-secondary)" aria-label="Pause {download.filename || 'download'}">
+          <button onclick={handlePause} class="icon-btn min-w-[44px] min-h-[44px] flex items-center justify-center rounded-lg" style="color: var(--text-secondary)" aria-label="{tr($locale, 'action.pause')} {download.filename || 'download'}">
             <Icon name="pause" size={16} />
           </button>
         {:else if download.status === "paused" || download.status === "queued"}
-          <button onclick={handleResume} class="icon-btn min-w-[44px] min-h-[44px] flex items-center justify-center rounded-lg" style="color: var(--text-secondary)" aria-label="Resume {download.filename || 'download'}">
+          <button onclick={handleResume} class="icon-btn min-w-[44px] min-h-[44px] flex items-center justify-center rounded-lg" style="color: var(--text-secondary)" aria-label="{tr($locale, 'action.resume')} {download.filename || 'download'}">
             <Icon name="play" size={16} />
           </button>
         {/if}
-        <button onclick={handleDelete} class="icon-btn min-w-[44px] min-h-[44px] flex items-center justify-center rounded-lg" style="color: var(--neon-accent)" aria-label="Delete {download.filename || 'download'}">
+        <button onclick={handleDelete} class="icon-btn min-w-[44px] min-h-[44px] flex items-center justify-center rounded-lg" style="color: var(--neon-accent)" aria-label="{tr($locale, 'action.delete')} {download.filename || 'download'}">
           {#if confirmingDelete}
-            <span class="text-[10px] font-bold">Sure?</span>
+            <span class="text-[10px] font-bold">{tr($locale, "action.sure")}</span>
           {:else}
             <Icon name="trash" size={16} />
           {/if}

--- a/web-ui/src/components/DownloadCard.svelte
+++ b/web-ui/src/components/DownloadCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { onDestroy } from "svelte";
-  import { pauseDownload, resumeDownload, retryDownload, deleteDownload, formatBytes, formatSpeed } from "../lib/api";
+  import { pauseDownload, resumeDownload, retryDownload, deleteDownload, addDownload, formatBytes, formatSpeed } from "../lib/api";
   import { openDetailPanel, selectedDownloadId, selectedIds, toggleSelection, crashReport } from "../lib/stores";
   import { addToast } from "../lib/toast";
   import { locale, tr } from "../lib/i18n";
@@ -73,7 +73,12 @@
     } else {
       clearTimeout(confirmTimer);
       confirmingDelete = false;
+      const url = download.url;
+      const label = download.filename || url;
       deleteDownload(download.id);
+      addToast("info", tr($locale, "toast.deleted_one"), label, {
+        action: { label: tr($locale, "action.undo"), onAction: () => addDownload(url) },
+      });
     }
   }
 

--- a/web-ui/src/components/DownloadCard.svelte
+++ b/web-ui/src/components/DownloadCard.svelte
@@ -65,21 +65,28 @@
 
   async function handlePause() { await pauseDownload(download.id); }
   async function handleResume() { await resumeDownload(download.id); }
-  function handleDelete(e: MouseEvent) {
+  async function handleDelete(e: MouseEvent) {
     e.stopPropagation();
     if (!confirmingDelete) {
       confirmingDelete = true;
       confirmTimer = setTimeout(() => { confirmingDelete = false; }, 2000);
-    } else {
-      clearTimeout(confirmTimer);
-      confirmingDelete = false;
-      const url = download.url;
-      const label = download.filename || url;
-      deleteDownload(download.id);
-      addToast("info", tr($locale, "toast.deleted_one"), label, {
-        action: { label: tr($locale, "action.undo"), onAction: () => addDownload(url) },
-      });
+      return;
     }
+    clearTimeout(confirmTimer);
+    confirmingDelete = false;
+    const url = download.url;
+    const label = download.filename || url;
+    try {
+      await deleteDownload(download.id);
+    } catch {
+      // Don't claim success (and don't offer an Undo that would re-enqueue) if
+      // the delete never committed.
+      addToast("error", tr($locale, "toast.delete_failed"), label);
+      return;
+    }
+    addToast("info", tr($locale, "toast.deleted_one"), label, {
+      action: { label: tr($locale, "action.undo"), onAction: () => addDownload(url) },
+    });
   }
 
   function select() {

--- a/web-ui/src/components/DownloadCompactRow.svelte
+++ b/web-ui/src/components/DownloadCompactRow.svelte
@@ -2,6 +2,7 @@
   import { onDestroy } from "svelte";
   import { pauseDownload, resumeDownload, retryDownload, deleteDownload, formatBytes, formatSpeed } from "../lib/api";
   import { openDetailPanel, selectedIds, toggleSelection } from "../lib/stores";
+  import { locale, tr } from "../lib/i18n";
   import Icon from "@amigo/ui/components/Icon.svelte";
 
   let { download }: { download: any } = $props();
@@ -27,6 +28,11 @@
     download.status === "failed" ? "var(--neon-accent)" :
     download.status === "paused" ? "var(--neon-warning)" :
     "var(--text-secondary)"
+  );
+
+  const KNOWN_STATUS = ["downloading", "completed", "failed", "paused", "queued"];
+  let statusLabel = $derived(
+    KNOWN_STATUS.includes(download.status) ? tr($locale, `status.${download.status}`) : download.status
   );
 
   let isActive = $derived(download.status === "downloading");
@@ -82,15 +88,15 @@
   <!-- Progress bar (inline) -->
   <div class="w-20 shrink-0">
     <div class="progress-bar">
-      <div class="progress-bar-fill" class:active={isActive} style="width: {progress}%"></div>
+      <div class="progress-bar-fill" class:active={isActive} style="width: {progress}%; transition: width var(--dur-base, 0.25s) var(--ease-out, ease)"></div>
     </div>
   </div>
 
   <!-- Progress % -->
-  <span class="w-10 text-right text-xs shrink-0" style="font-family: var(--font-mono); color: var(--text-secondary)">{progress}%</span>
+  <span class="w-10 text-right text-xs shrink-0 tabular-nums" style="font-family: var(--font-mono); color: var(--text-secondary)">{progress}%</span>
 
   <!-- Speed -->
-  <span class="w-20 text-right text-xs shrink-0" style="font-family: var(--font-mono); color: var(--neon-primary)">
+  <span class="w-20 text-right text-xs shrink-0 tabular-nums" style="font-family: var(--font-mono); color: var(--neon-primary)">
     {isActive ? formatSpeed(download.speed) : "\u2014"}
   </span>
 
@@ -99,27 +105,27 @@
     class="w-16 text-center text-[10px] font-semibold uppercase shrink-0 px-1.5 py-0.5 rounded-full"
     style="color: {statusColor}; background: color-mix(in srgb, {statusColor} 10%, transparent)"
   >
-    {download.status}
+    {statusLabel}
   </span>
 
   <!-- Actions -->
   <div class="flex gap-0.5 shrink-0" onclick={(e) => e.stopPropagation()}>
     {#if download.status === "downloading"}
-      <button onclick={() => pauseDownload(download.id)} class="icon-btn p-2 rounded min-w-[36px] min-h-[36px] flex items-center justify-center" style="color: var(--text-secondary)" aria-label="Pause">
+      <button onclick={() => pauseDownload(download.id)} class="icon-btn p-2 rounded min-w-[36px] min-h-[36px] flex items-center justify-center" style="color: var(--text-secondary)" aria-label={tr($locale, "action.pause")}>
         <Icon name="pause" size={14} />
       </button>
     {:else if download.status === "paused" || download.status === "queued"}
-      <button onclick={() => resumeDownload(download.id)} class="icon-btn p-2 rounded min-w-[36px] min-h-[36px] flex items-center justify-center" style="color: var(--text-secondary)" aria-label="Resume">
+      <button onclick={() => resumeDownload(download.id)} class="icon-btn p-2 rounded min-w-[36px] min-h-[36px] flex items-center justify-center" style="color: var(--text-secondary)" aria-label={tr($locale, "action.resume")}>
         <Icon name="play" size={14} />
       </button>
     {:else if download.status === "failed"}
-      <button onclick={() => retryDownload(download.id)} class="icon-btn p-2 rounded min-w-[36px] min-h-[36px] flex items-center justify-center" style="color: var(--neon-primary)" aria-label="Retry">
+      <button onclick={() => retryDownload(download.id)} class="icon-btn p-2 rounded min-w-[36px] min-h-[36px] flex items-center justify-center" style="color: var(--neon-primary)" aria-label={tr($locale, "action.retry")}>
         <Icon name="refresh" size={14} />
       </button>
     {/if}
-    <button onclick={handleDelete} class="icon-btn p-2 rounded min-w-[36px] min-h-[36px] flex items-center justify-center" style="color: {confirmingDelete ? 'var(--neon-accent)' : 'var(--text-secondary)'}" aria-label="Delete">
+    <button onclick={handleDelete} class="icon-btn p-2 rounded min-w-[36px] min-h-[36px] flex items-center justify-center" style="color: {confirmingDelete ? 'var(--neon-accent)' : 'var(--text-secondary)'}" aria-label={tr($locale, "action.delete")}>
       {#if confirmingDelete}
-        <span class="text-[10px] font-semibold px-1">Sure?</span>
+        <span class="text-[10px] font-semibold px-1">{tr($locale, "action.sure")}</span>
       {:else}
         <Icon name="trash" size={14} />
       {/if}

--- a/web-ui/src/components/FeedbackDialog.svelte
+++ b/web-ui/src/components/FeedbackDialog.svelte
@@ -2,6 +2,8 @@
   import { onMount } from "svelte";
   import { addToast } from "../lib/toast";
   import { crashReport } from "../lib/stores";
+  import { focusTrap } from "../lib/focusTrap";
+  import { locale, tr } from "../lib/i18n";
   import Icon from "@amigo/ui/components/Icon.svelte";
 
   let { onclose }: { onclose: () => void } = $props();
@@ -69,14 +71,15 @@
 </script>
 
 <div class="fixed inset-0 z-50 flex items-center justify-center p-4">
-  <div class="fixed inset-0 bg-black/70" onclick={onclose}></div>
+  <button class="fixed inset-0 bg-black/70" onclick={onclose} aria-label={tr($locale, "common.close")}></button>
 
   <div
+    use:focusTrap
     role="dialog"
     aria-modal="true"
     aria-labelledby="feedback-title"
-    class="relative z-10 w-full max-w-sm rounded-2xl shadow-2xl p-6"
-    style="background: var(--bg-surface); border: 1px solid var(--border-color)"
+    class="relative z-10 w-full max-w-sm rounded-2xl shadow-2xl p-6 neon-card"
+    style="background: var(--bg-surface)"
   >
     <div class="flex items-center justify-between mb-5">
       <h2 id="feedback-title" class="text-lg font-bold" style="color: var(--text-primary)">Feedback</h2>
@@ -84,7 +87,7 @@
         onclick={onclose}
         class="p-1.5 rounded-lg min-w-[44px] min-h-[44px] flex items-center justify-center"
         style="color: var(--text-secondary)"
-        aria-label="Close dialog"
+        aria-label={tr($locale, "common.close")}
       >
         <Icon name="x" size={18} />
       </button>

--- a/web-ui/src/components/FeedbackDialog.svelte
+++ b/web-ui/src/components/FeedbackDialog.svelte
@@ -82,7 +82,7 @@
     style="background: var(--bg-surface)"
   >
     <div class="flex items-center justify-between mb-5">
-      <h2 id="feedback-title" class="text-lg font-bold" style="color: var(--text-primary)">Feedback</h2>
+      <h2 id="feedback-title" class="text-lg font-bold" style="color: var(--text-primary)">{tr($locale, "feedback.title")}</h2>
       <button
         onclick={onclose}
         class="p-1.5 rounded-lg min-w-[44px] min-h-[44px] flex items-center justify-center"
@@ -95,9 +95,9 @@
 
     {#if autoReported}
       <div class="rounded-xl p-3 mb-4 text-center" style="background: color-mix(in srgb, var(--neon-warning) 8%, transparent)">
-        <p class="text-xs font-semibold" style="color: var(--neon-warning)">Crash auto-reported</p>
+        <p class="text-xs font-semibold" style="color: var(--neon-warning)">{tr($locale, "feedback.crash_reported")}</p>
         {#if resultUrl}
-          <a href={resultUrl} target="_blank" rel="noopener" class="text-xs underline" style="color: var(--neon-primary)">View issue &rarr;</a>
+          <a href={resultUrl} target="_blank" rel="noopener" class="text-xs underline" style="color: var(--neon-primary)">{tr($locale, "feedback.view_issue")} &rarr;</a>
         {/if}
       </div>
     {/if}
@@ -113,8 +113,8 @@
         <Icon name="flag" size={20} />
       </div>
       <div class="flex-1">
-        <p class="font-semibold text-sm" style="color: var(--text-primary)">Report a Bug</p>
-        <p class="text-xs" style="color: var(--text-secondary)">Opens GitHub with pre-filled template</p>
+        <p class="font-semibold text-sm" style="color: var(--text-primary)">{tr($locale, "feedback.report_bug")}</p>
+        <p class="text-xs" style="color: var(--text-secondary)">{tr($locale, "feedback.opens_github")}</p>
       </div>
       <Icon name="external" size={14} class="text-[var(--text-secondary)]" />
     </a>
@@ -130,17 +130,17 @@
         <Icon name="plus" size={20} />
       </div>
       <div class="flex-1">
-        <p class="font-semibold text-sm" style="color: var(--text-primary)">Request a Feature</p>
-        <p class="text-xs" style="color: var(--text-secondary)">Opens GitHub with pre-filled template</p>
+        <p class="font-semibold text-sm" style="color: var(--text-primary)">{tr($locale, "feedback.request_feature")}</p>
+        <p class="text-xs" style="color: var(--text-secondary)">{tr($locale, "feedback.opens_github")}</p>
       </div>
       <Icon name="external" size={14} class="text-[var(--text-secondary)]" />
     </a>
 
     <p class="text-[10px] text-center" style="color: var(--text-secondary)">
       {#if systemInfo?.feedback_enabled}
-        Crashes are automatically reported.
+        {tr($locale, "feedback.auto_on")}
       {:else}
-        Set AMIGO_GITHUB_TOKEN for automatic crash reporting.
+        {tr($locale, "feedback.auto_off")}
       {/if}
     </p>
   </div>

--- a/web-ui/src/components/MobileNav.svelte
+++ b/web-ui/src/components/MobileNav.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+  import type { Page } from "../lib/stores";
+  import { locale, tr } from "../lib/i18n";
+  import Icon from "@amigo/ui/components/Icon.svelte";
+
+  let { current, onnavigate, onadd }:
+    { current: Page; onnavigate: (page: Page) => void; onadd: () => void } = $props();
+
+  // Two items either side of the central Add FAB.
+  const left: { id: Page; key: string; icon: string }[] = [
+    { id: "downloads", key: "nav.downloads", icon: "arrow-down" },
+    { id: "plugins", key: "nav.plugins", icon: "puzzle" },
+  ];
+  const right: { id: Page; key: string; icon: string }[] = [
+    { id: "history", key: "nav.history", icon: "clock" },
+    { id: "settings", key: "nav.settings", icon: "gear" },
+  ];
+</script>
+
+<nav
+  aria-label={tr($locale, "nav.management")}
+  class="mobile-nav md:hidden fixed bottom-0 inset-x-0 z-40 flex items-stretch justify-around"
+  style="background: color-mix(in srgb, var(--bg-surface) 92%, transparent); border-top: 1px solid var(--border-color); backdrop-filter: blur(12px); padding-bottom: env(safe-area-inset-bottom, 0px)"
+>
+  {#each left as item}
+    <button
+      onclick={() => onnavigate(item.id)}
+      aria-current={current === item.id ? "page" : undefined}
+      class="mobile-tab"
+      class:active={current === item.id}
+    >
+      <Icon name={item.icon} size={20} />
+      <span class="text-[10px] font-medium">{tr($locale, item.key)}</span>
+    </button>
+  {/each}
+
+  <!-- Center Add FAB -->
+  <div class="relative flex items-end justify-center" style="width: 64px">
+    <button
+      onclick={onadd}
+      aria-label={tr($locale, "cmd.add_download")}
+      class="fab absolute -top-5 w-14 h-14 rounded-full flex items-center justify-center"
+      style="background: var(--neon-primary); color: var(--bg-deep); box-shadow: var(--neon-glow-md), 0 6px 16px rgb(0 0 0 / 30%)"
+    >
+      <Icon name="plus" size={24} />
+    </button>
+  </div>
+
+  {#each right as item}
+    <button
+      onclick={() => onnavigate(item.id)}
+      aria-current={current === item.id ? "page" : undefined}
+      class="mobile-tab"
+      class:active={current === item.id}
+    >
+      <Icon name={item.icon} size={20} />
+      <span class="text-[10px] font-medium">{tr($locale, item.key)}</span>
+    </button>
+  {/each}
+</nav>
+
+<style>
+  .mobile-tab {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 2px;
+    min-height: 56px;
+    padding: 6px 0;
+    color: var(--text-secondary);
+    transition: color var(--dur-fast, 0.15s) var(--ease-out, ease);
+  }
+
+  .mobile-tab.active {
+    color: var(--neon-primary);
+  }
+
+  .mobile-tab.active :global(svg) {
+    filter: drop-shadow(0 0 var(--neon-drop-blur, 3px) currentcolor);
+  }
+
+  .fab {
+    transition: transform var(--dur-fast, 0.15s) var(--ease-spring, ease);
+  }
+
+  .fab:active {
+    transform: scale(0.92);
+  }
+</style>

--- a/web-ui/src/components/ShortcutsDialog.svelte
+++ b/web-ui/src/components/ShortcutsDialog.svelte
@@ -1,34 +1,40 @@
 <script lang="ts">
+  import { locale, tr } from "../lib/i18n";
+  import { focusTrap } from "../lib/focusTrap";
+  import { scaleFade, dur } from "../lib/motion";
+  import { fade } from "svelte/transition";
   import Icon from "@amigo/ui/components/Icon.svelte";
 
   let { onclose }: { onclose: () => void } = $props();
 
-  const shortcuts = [
-    { keys: "Ctrl + N", desc: "Add download" },
-    { keys: "Ctrl + L", desc: "Add download" },
-    { keys: "Esc", desc: "Close panel / dialog" },
-    { keys: "1 – 4", desc: "Navigate pages" },
-    { keys: "?", desc: "Show this help" },
-  ];
+  let shortcuts = $derived([
+    { keys: "⌘ / Ctrl + K", desc: tr($locale, "shortcuts.command_palette") },
+    { keys: "Ctrl + N", desc: tr($locale, "shortcuts.add") },
+    { keys: "Esc", desc: tr($locale, "shortcuts.close") },
+    { keys: "1 – 4", desc: tr($locale, "shortcuts.navigate") },
+    { keys: "?", desc: tr($locale, "shortcuts.help") },
+  ]);
 </script>
 
 <div class="fixed inset-0 z-50 flex items-center justify-center p-4">
-  <button class="fixed inset-0 bg-black/60" onclick={onclose} aria-label="Close shortcuts"></button>
+  <button class="fixed inset-0 bg-black/60" onclick={onclose} aria-label={tr($locale, "common.close")} transition:fade={{ duration: dur(150) }}></button>
 
   <div
+    use:focusTrap
     role="dialog"
     aria-modal="true"
-    aria-label="Keyboard shortcuts"
-    class="relative z-10 w-full max-w-sm rounded-xl p-5"
-    style="background: var(--bg-surface); border: 1px solid var(--border-color)"
+    aria-label={tr($locale, "shortcuts.title")}
+    class="relative z-10 w-full max-w-sm rounded-xl p-5 neon-card"
+    style="background: var(--bg-surface)"
+    transition:scaleFade={{ duration: dur(180), y: 8 }}
   >
     <div class="flex items-center justify-between mb-4">
-      <h2 class="text-sm font-bold" style="color: var(--text-primary)">Keyboard Shortcuts</h2>
+      <h2 class="text-sm font-bold" style="color: var(--text-primary)">{tr($locale, "shortcuts.title")}</h2>
       <button
         onclick={onclose}
         class="icon-btn p-1.5 rounded-lg min-w-[44px] min-h-[44px] flex items-center justify-center"
         style="color: var(--text-secondary)"
-        aria-label="Close"
+        aria-label={tr($locale, "common.close")}
       >
         <Icon name="x" size={16} />
       </button>

--- a/web-ui/src/components/SidePanel.svelte
+++ b/web-ui/src/components/SidePanel.svelte
@@ -11,7 +11,7 @@
   let title = $derived(
     $sidePanelMode === "add"
       ? tr($locale, "add.title")
-      : $selectedDownload?.filename || $selectedDownload?.url || tr($locale, "add.title")
+      : $selectedDownload?.filename || $selectedDownload?.url || tr($locale, "panel.details")
   );
 </script>
 
@@ -19,7 +19,7 @@
   <!-- Desktop panel (lg+) -->
   <div
     role="complementary"
-    aria-label={$sidePanelMode === "add" ? "Add download" : "Download details"}
+    aria-label={$sidePanelMode === "add" ? tr($locale, "add.title") : tr($locale, "panel.details")}
     class="hidden lg:flex flex-col w-80 shrink-0 border-l overflow-y-auto"
     style="background: var(--bg-surface); border-color: var(--border-color)"
     transition:fly={{ x: 320, duration: 200 }}
@@ -56,7 +56,7 @@
       use:focusTrap
       role="dialog"
       aria-modal="true"
-      aria-label={$sidePanelMode === "add" ? "Add download" : "Download details"}
+      aria-label={$sidePanelMode === "add" ? tr($locale, "add.title") : tr($locale, "panel.details")}
       class="absolute right-0 top-0 bottom-0 w-full max-w-sm flex flex-col overflow-y-auto"
       style="background: var(--bg-surface)"
       transition:fly={{ x: 384, duration: 250 }}

--- a/web-ui/src/components/SidePanel.svelte
+++ b/web-ui/src/components/SidePanel.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
   import { fly } from "svelte/transition";
   import { sidePanelMode, selectedDownload, closeSidePanel } from "../lib/stores";
+  import { focusTrap } from "../lib/focusTrap";
+  import { locale, tr } from "../lib/i18n";
   import DetailPanel from "./DetailPanel.svelte";
   import AddPanel from "./AddPanel.svelte";
   import Icon from "@amigo/ui/components/Icon.svelte";
@@ -8,8 +10,8 @@
   let isOpen = $derived($sidePanelMode !== null);
   let title = $derived(
     $sidePanelMode === "add"
-      ? "Add Download"
-      : $selectedDownload?.filename || "Download Details"
+      ? tr($locale, "add.title")
+      : $selectedDownload?.filename || $selectedDownload?.url || tr($locale, "add.title")
   );
 </script>
 
@@ -29,7 +31,7 @@
         onclick={closeSidePanel}
         class="icon-btn p-1.5 rounded-lg min-w-[44px] min-h-[44px] flex items-center justify-center"
         style="color: var(--text-secondary)"
-        aria-label="Close panel"
+        aria-label={tr($locale, "common.close")}
       >
         <Icon name="x" size={16} />
       </button>
@@ -48,10 +50,12 @@
     <button
       class="absolute inset-0 bg-black/60"
       onclick={closeSidePanel}
-      aria-label="Close panel"
+      aria-label={tr($locale, "common.close")}
     ></button>
     <div
-      role="complementary"
+      use:focusTrap
+      role="dialog"
+      aria-modal="true"
       aria-label={$sidePanelMode === "add" ? "Add download" : "Download details"}
       class="absolute right-0 top-0 bottom-0 w-full max-w-sm flex flex-col overflow-y-auto"
       style="background: var(--bg-surface)"
@@ -64,7 +68,7 @@
           onclick={closeSidePanel}
           class="icon-btn p-2 rounded-lg min-w-[44px] min-h-[44px] flex items-center justify-center"
           style="color: var(--text-secondary)"
-          aria-label="Close panel"
+          aria-label={tr($locale, "common.close")}
         >
           <Icon name="x" size={18} />
         </button>

--- a/web-ui/src/components/Toasts.svelte
+++ b/web-ui/src/components/Toasts.svelte
@@ -17,7 +17,9 @@
   // Non-color cue: a distinct glyph per type so the meaning survives without
   // relying on the accent colour alone (WCAG — don't encode by colour only).
   function iconFor(type: Toast["type"]): string {
-    return type === "success" ? "check" : "info";
+    if (type === "success") return "check";
+    if (type === "error") return "alert";
+    return "info";
   }
 
   function handleAction(toast: Toast) {

--- a/web-ui/src/components/Toasts.svelte
+++ b/web-ui/src/components/Toasts.svelte
@@ -1,14 +1,28 @@
 <script lang="ts">
-  import { toasts, removeToast, type Toast } from "../lib/toast";
+  import { flip } from "svelte/animate";
+  import { fly } from "svelte/transition";
+  import { toasts, removeToast, pauseToast, resumeToast, type Toast } from "../lib/toast";
+  import { dur, flipConfig } from "../lib/motion";
+  import { locale, tr } from "../lib/i18n";
   import Icon from "@amigo/ui/components/Icon.svelte";
 
   function colorFor(type: Toast["type"]) {
     switch (type) {
       case "success": return "var(--neon-success)";
       case "error": return "var(--neon-accent)";
-      case "info": return "var(--neon-primary)";
       default: return "var(--neon-primary)";
     }
+  }
+
+  // Non-color cue: a distinct glyph per type so the meaning survives without
+  // relying on the accent colour alone (WCAG — don't encode by colour only).
+  function iconFor(type: Toast["type"]): string {
+    return type === "success" ? "check" : "info";
+  }
+
+  function handleAction(toast: Toast) {
+    toast.action?.onAction();
+    removeToast(toast.id);
   }
 </script>
 
@@ -16,44 +30,50 @@
 <div class="fixed bottom-4 z-[100] flex flex-col gap-2 pointer-events-none max-w-sm" style="right: calc(1rem + 8px)">
   {#each $toasts as toast (toast.id)}
     <div
-      class="toast-enter pointer-events-auto flex items-start gap-3 rounded-xl px-4 py-3 shadow-xl border"
+      class="pointer-events-auto flex items-start gap-3 rounded-xl px-4 py-3 shadow-xl border"
       style="background: var(--bg-surface); border-color: var(--border-color)"
+      role={toast.type === "error" ? "alert" : "status"}
+      aria-live={toast.type === "error" ? "assertive" : "polite"}
+      onmouseenter={() => pauseToast(toast.id)}
+      onmouseleave={() => resumeToast(toast.id)}
+      onfocusin={() => pauseToast(toast.id)}
+      onfocusout={() => resumeToast(toast.id)}
+      in:fly={{ x: 24, duration: dur(280), opacity: 0 }}
+      out:fly={{ x: 24, duration: dur(180), opacity: 0 }}
+      animate:flip={flipConfig}
     >
-      <!-- Color bar — neon accent, the 10% pop -->
-      <div class="w-1 h-8 rounded-full shrink-0 mt-0.5" style="background: {colorFor(toast.type)}"></div>
+      <!-- Type glyph on a colour chip — the 10% neon pop + shape cue -->
+      <div
+        class="w-6 h-6 rounded-lg shrink-0 mt-0.5 flex items-center justify-center"
+        style="color: {colorFor(toast.type)}; background: color-mix(in srgb, {colorFor(toast.type)} 14%, transparent)"
+      >
+        <Icon name={iconFor(toast.type)} size={14} />
+      </div>
 
       <div class="flex-1 min-w-0">
         <p class="text-sm font-semibold" style="color: var(--text-primary)">{toast.title}</p>
         {#if toast.message}
-          <p class="text-xs mt-0.5 truncate" style="color: var(--text-secondary)">{toast.message}</p>
+          <p class="text-xs mt-0.5 break-words line-clamp-2" style="color: var(--text-secondary)">{toast.message}</p>
+        {/if}
+        {#if toast.action}
+          <button
+            onclick={() => handleAction(toast)}
+            class="action-btn mt-2 text-xs font-semibold px-2.5 py-1 rounded-md"
+            style="color: {colorFor(toast.type)}; background: color-mix(in srgb, {colorFor(toast.type)} 12%, transparent)"
+          >
+            {toast.action.label}
+          </button>
         {/if}
       </div>
 
       <button
         onclick={() => removeToast(toast.id)}
-        class="shrink-0 p-1 rounded min-w-[44px] min-h-[44px] flex items-center justify-center"
+        class="icon-btn shrink-0 p-1 rounded-lg min-w-[44px] min-h-[44px] flex items-center justify-center -mr-2 -mt-1"
         style="color: var(--text-secondary)"
-        aria-label="Dismiss notification"
+        aria-label={tr($locale, "common.close")}
       >
         <Icon name="x" size={14} />
       </button>
     </div>
   {/each}
 </div>
-
-<style>
-  @keyframes toast-slide-in {
-    from {
-      opacity: 0;
-      transform: translateX(100%) scale(0.95);
-    }
-    to {
-      opacity: 1;
-      transform: translateX(0) scale(1);
-    }
-  }
-
-  .toast-enter {
-    animation: toast-slide-in 0.3s cubic-bezier(0.16, 1, 0.3, 1) forwards;
-  }
-</style>

--- a/web-ui/src/components/settings/SettingsAppearance.svelte
+++ b/web-ui/src/components/settings/SettingsAppearance.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { theme, palette, neonIntensity, getNeonLabel, type ColorPalette, type ThemeMode } from "../../lib/stores";
+  import { locale, tr } from "../../lib/i18n";
   import Icon from "@amigo/ui/components/Icon.svelte";
 
   const paletteOptions: { id: ColorPalette; label: string; color: string }[] = [
@@ -11,25 +12,31 @@
     { id: "rose", label: "Rose", color: "#f43f5e" },
   ];
 
+  const themeModes: { id: ThemeMode; key: string }[] = [
+    { id: "dark", key: "theme.dark" },
+    { id: "light", key: "theme.light" },
+  ];
+
   let label = $derived(getNeonLabel($neonIntensity));
 </script>
 
 <section>
-  <h3 class="text-lg font-bold mb-4" style="color: var(--text-primary)">Appearance</h3>
+  <h3 class="text-lg font-bold mb-4" style="color: var(--text-primary)">{tr($locale, "settings.appearance")}</h3>
 
   <!-- Theme mode -->
   <div class="neon-card rounded-xl p-5 mb-4" style="background: var(--bg-surface)">
-    <label class="text-sm font-semibold mb-3 block" style="color: var(--text-primary)">Theme</label>
+    <span class="text-sm font-semibold mb-3 block" style="color: var(--text-primary)">{tr($locale, "settings.theme")}</span>
     <div class="flex gap-3">
-      {#each [{ id: "dark", label: "Dark" }, { id: "light", label: "Light" }] as mode}
+      {#each themeModes as mode}
         <button
-          onclick={() => theme.set(mode.id as ThemeMode)}
+          onclick={() => theme.set(mode.id)}
+          aria-pressed={$theme === mode.id}
           class="flex-1 py-3 rounded-xl text-sm font-medium transition-colors"
           style={$theme === mode.id
             ? "background: color-mix(in srgb, var(--neon-primary) 15%, transparent); color: var(--neon-primary); border: 1px solid color-mix(in srgb, var(--neon-primary) 20%, transparent)"
             : "background: var(--bg-surface-2); color: var(--text-secondary); border: 1px solid transparent"}
         >
-          {mode.label}
+          {tr($locale, mode.key)}
         </button>
       {/each}
     </div>
@@ -37,7 +44,7 @@
 
   <!-- Color palette -->
   <div class="neon-card rounded-xl p-5 mb-4" style="background: var(--bg-surface)">
-    <label class="text-sm font-semibold mb-3 block" style="color: var(--text-primary)">Color Palette</label>
+    <span class="text-sm font-semibold mb-3 block" style="color: var(--text-primary)">{tr($locale, "settings.color_palette")}</span>
     <div class="flex gap-3 flex-wrap">
       {#each paletteOptions as opt}
         <button
@@ -60,7 +67,7 @@
 
   <!-- Neon intensity -->
   <div class="neon-card rounded-xl p-5" style="background: var(--bg-surface)">
-    <label class="text-sm font-semibold mb-3 block" style="color: var(--text-primary)">Neon Intensity</label>
+    <span class="text-sm font-semibold mb-3 block" style="color: var(--text-primary)">{tr($locale, "settings.neon_intensity")}</span>
     <div class="neon-slider">
       <Icon name="bolt" size={16} />
       <input
@@ -70,7 +77,7 @@
         step="0.25"
         value={$neonIntensity}
         oninput={(e) => neonIntensity.set(parseFloat((e.target as HTMLInputElement).value))}
-        aria-label="Neon intensity"
+        aria-label={tr($locale, "settings.neon_intensity")}
       />
       <span class="neon-slider-label">{label}</span>
     </div>

--- a/web-ui/src/components/settings/SettingsDownloads.svelte
+++ b/web-ui/src/components/settings/SettingsDownloads.svelte
@@ -1,74 +1,75 @@
 <script lang="ts">
   import type { AppConfig } from "../../lib/api";
+  import { locale, tr } from "../../lib/i18n";
 
   let { config, onsave }: { config: AppConfig; onsave: () => void } = $props();
+  const inputStyle =
+    "font-family: var(--font-mono);background: var(--bg-surface-2); border: 1px solid var(--border-color); color: var(--text-primary)";
 </script>
 
 <section>
-  <h3 class="text-lg font-bold mb-4" style="color: var(--text-primary)">Downloads</h3>
+  <h3 class="text-lg font-bold mb-4" style="color: var(--text-primary)">{tr($locale, "settings.downloads")}</h3>
   <div class="rounded-xl p-5 space-y-4" style="background: var(--bg-surface); border: 1px solid var(--border-color)">
-    <div>
-      <label class="text-sm font-semibold mb-1.5 block" style="color: var(--text-primary)">Download Directory</label>
+    <label class="block">
+      <span class="text-sm font-semibold mb-1.5 block" style="color: var(--text-primary)">{tr($locale, "settings.download_dir")}</span>
       <input
         type="text"
         bind:value={config.download_dir}
         class="w-full rounded-lg px-4 py-2.5 text-sm"
-        style="font-family: var(--font-mono);background: var(--bg-surface-2); border: 1px solid var(--border-color); color: var(--text-primary)"
+        style={inputStyle}
       />
-    </div>
-    <div>
-      <label class="text-sm font-semibold mb-1.5 block" style="color: var(--text-primary)">Max Concurrent Downloads</label>
+    </label>
+    <label class="block">
+      <span class="text-sm font-semibold mb-1.5 block" style="color: var(--text-primary)">{tr($locale, "settings.max_concurrent")}</span>
       <input
         type="number"
         bind:value={config.max_concurrent_downloads}
         min="1"
         max="50"
         class="w-32 rounded-lg px-4 py-2.5 text-sm"
-        style="font-family: var(--font-mono);background: var(--bg-surface-2); border: 1px solid var(--border-color); color: var(--text-primary)"
+        style={inputStyle}
       />
-    </div>
+    </label>
     <div>
-      <label class="text-sm font-semibold mb-1.5 block" style="color: var(--text-primary)">Global Speed Limit</label>
+      <span class="text-sm font-semibold mb-1.5 block" style="color: var(--text-primary)">{tr($locale, "settings.speed_limit")}</span>
       <div class="flex items-center gap-2">
         <input
           type="number"
           bind:value={config.bandwidth.global_limit}
           min="0"
           class="w-32 rounded-lg px-4 py-2.5 text-sm"
-          style="font-family: var(--font-mono);background: var(--bg-surface-2); border: 1px solid var(--border-color); color: var(--text-primary)"
+          style={inputStyle}
+          aria-label={tr($locale, "settings.speed_limit")}
         />
-        <span class="text-sm" style="color: var(--text-secondary)">B/s (0 = unlimited)</span>
+        <span class="text-sm" style="color: var(--text-secondary)">{tr($locale, "settings.speed_limit_hint")}</span>
       </div>
     </div>
     <div>
-      <h4 class="text-sm font-semibold mb-3" style="color: var(--text-primary)">Retry Behavior</h4>
+      <h4 class="text-sm font-semibold mb-3" style="color: var(--text-primary)">{tr($locale, "settings.retry_behavior")}</h4>
       <div class="space-y-3">
-        <div>
-          <label class="text-xs mb-1 block" style="color: var(--text-secondary)">Max retries before giving up</label>
+        <label class="block">
+          <span class="text-xs mb-1 block" style="color: var(--text-secondary)">{tr($locale, "settings.max_retries")}</span>
           <input type="number" bind:value={config.retry.max_retries} min="0" max="20"
-            class="w-32 rounded-lg px-4 py-2.5 text-sm"
-            style="font-family: var(--font-mono);background: var(--bg-surface-2); border: 1px solid var(--border-color); color: var(--text-primary)" />
-        </div>
+            class="w-32 rounded-lg px-4 py-2.5 text-sm" style={inputStyle} />
+        </label>
         <div class="flex gap-4">
-          <div>
-            <label class="text-xs mb-1 block" style="color: var(--text-secondary)">Initial delay (s)</label>
+          <label class="block">
+            <span class="text-xs mb-1 block" style="color: var(--text-secondary)">{tr($locale, "settings.initial_delay")}</span>
             <input type="number" bind:value={config.retry.base_delay_secs} min="0.1" max="30" step="0.5"
-              class="w-28 rounded-lg px-4 py-2.5 text-sm"
-              style="font-family: var(--font-mono);background: var(--bg-surface-2); border: 1px solid var(--border-color); color: var(--text-primary)" />
-          </div>
-          <div>
-            <label class="text-xs mb-1 block" style="color: var(--text-secondary)">Max delay (s)</label>
+              class="w-28 rounded-lg px-4 py-2.5 text-sm" style={inputStyle} />
+          </label>
+          <label class="block">
+            <span class="text-xs mb-1 block" style="color: var(--text-secondary)">{tr($locale, "settings.max_delay")}</span>
             <input type="number" bind:value={config.retry.max_delay_secs} min="1" max="600" step="1"
-              class="w-28 rounded-lg px-4 py-2.5 text-sm"
-              style="font-family: var(--font-mono);background: var(--bg-surface-2); border: 1px solid var(--border-color); color: var(--text-primary)" />
-          </div>
+              class="w-28 rounded-lg px-4 py-2.5 text-sm" style={inputStyle} />
+          </label>
         </div>
       </div>
     </div>
     <button
       onclick={onsave}
-      class="px-4 py-2 rounded-lg text-sm font-semibold"
+      class="action-btn px-4 py-2 rounded-lg text-sm font-semibold"
       style="background: var(--neon-primary); color: var(--bg-deep)"
-    >Save</button>
+    >{tr($locale, "common.save")}</button>
   </div>
 </section>

--- a/web-ui/src/components/settings/SettingsWebhooks.svelte
+++ b/web-ui/src/components/settings/SettingsWebhooks.svelte
@@ -23,9 +23,9 @@
       showAdd = false;
       name = url = secret = "";
       events = "*";
-      addToast("success", "Webhook added");
+      addToast("success", tr($locale, "webhook.added"));
     } catch {
-      addToast("error", "Failed to add webhook");
+      addToast("error", tr($locale, "webhook.add_failed"));
     }
   }
 
@@ -33,18 +33,18 @@
     try {
       await deleteWebhook(id);
       webhooks = webhooks.filter(w => w.id !== id);
-      addToast("info", "Webhook removed");
+      addToast("info", tr($locale, "webhook.removed"));
     } catch {
-      addToast("error", "Failed to delete webhook");
+      addToast("error", tr($locale, "webhook.delete_failed"));
     }
   }
 
   async function handleTest(id: string) {
     try {
       const result = await testWebhook(id);
-      addToast("success", "Test sent", `Status: ${result.status || "OK"}`);
+      addToast("success", tr($locale, "webhook.test_sent"), `Status: ${result.status || "OK"}`);
     } catch {
-      addToast("error", "Test failed");
+      addToast("error", tr($locale, "webhook.test_failed"));
     }
   }
 </script>
@@ -62,22 +62,22 @@
   {#if showAdd}
     <div class="rounded-xl p-5 mb-4 space-y-3" style="background: var(--bg-surface); border: 1px solid var(--border-color)">
       <label class="block">
-        <span class="text-xs font-semibold mb-1 block" style="color: var(--text-secondary)">Name</span>
+        <span class="text-xs font-semibold mb-1 block" style="color: var(--text-secondary)">{tr($locale, "webhook.name")}</span>
         <input bind:value={name} type="text" placeholder="Discord Notifications"
           class="w-full rounded-lg px-3 py-2 text-sm" style={inputStyle} />
       </label>
       <label class="block">
-        <span class="text-xs font-semibold mb-1 block" style="color: var(--text-secondary)">URL</span>
+        <span class="text-xs font-semibold mb-1 block" style="color: var(--text-secondary)">{tr($locale, "webhook.url")}</span>
         <input bind:value={url} type="url" placeholder="https://discord.com/api/webhooks/..."
           class="w-full rounded-lg px-3 py-2 text-sm" style={monoInputStyle} />
       </label>
       <label class="block">
-        <span class="text-xs font-semibold mb-1 block" style="color: var(--text-secondary)">Secret <span class="opacity-50">(optional)</span></span>
+        <span class="text-xs font-semibold mb-1 block" style="color: var(--text-secondary)">{tr($locale, "webhook.secret")} <span class="opacity-50">({tr($locale, "webhook.optional")})</span></span>
         <input bind:value={secret} type="text" placeholder="my-secret-key"
           class="w-full rounded-lg px-3 py-2 text-sm" style={monoInputStyle} />
       </label>
       <label class="block">
-        <span class="text-xs font-semibold mb-1 block" style="color: var(--text-secondary)">Events <span class="opacity-50">(comma-separated, * = all)</span></span>
+        <span class="text-xs font-semibold mb-1 block" style="color: var(--text-secondary)">{tr($locale, "webhook.events")} <span class="opacity-50">({tr($locale, "webhook.events_hint")})</span></span>
         <input bind:value={events} type="text" placeholder="download.completed, download.failed"
           class="w-full rounded-lg px-3 py-2 text-sm" style={monoInputStyle} />
       </label>
@@ -107,8 +107,8 @@
             <p class="font-semibold text-sm truncate" style="color: var(--text-primary)">{wh.name}</p>
             <p class="text-xs truncate" style="font-family: var(--font-mono);color: var(--text-secondary)">{wh.url}</p>
             <p class="text-[10px] mt-0.5" style="color: var(--text-secondary)">
-              Events: {wh.events?.join(", ") || "*"}
-              {#if wh.secret}&middot; signed{/if}
+              {tr($locale, "webhook.events")}: {wh.events?.join(", ") || "*"}
+              {#if wh.secret}&middot; {tr($locale, "webhook.signed")}{/if}
             </p>
           </div>
           <div class="flex gap-1.5 shrink-0">

--- a/web-ui/src/components/settings/SettingsWebhooks.svelte
+++ b/web-ui/src/components/settings/SettingsWebhooks.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { getWebhooks, createWebhook, deleteWebhook, testWebhook } from "../../lib/api";
   import { addToast } from "../../lib/toast";
+  import { locale, tr } from "../../lib/i18n";
 
   let { webhooks = $bindable([]) }: { webhooks: any[] } = $props();
   let showAdd = $state(false);
@@ -8,6 +9,10 @@
   let url = $state("");
   let secret = $state("");
   let events = $state("*");
+
+  const inputStyle =
+    "background: var(--bg-surface-2); border: 1px solid var(--border-color); color: var(--text-primary)";
+  const monoInputStyle = `font-family: var(--font-mono);${inputStyle}`;
 
   async function handleAdd() {
     if (!name.trim() || !url.trim()) return;
@@ -46,48 +51,44 @@
 
 <section>
   <div class="flex items-center justify-between mb-4">
-    <h3 class="text-lg font-bold" style="color: var(--text-primary)">Webhooks</h3>
+    <h3 class="text-lg font-bold" style="color: var(--text-primary)">{tr($locale, "settings.webhooks")}</h3>
     <button
       onclick={() => (showAdd = !showAdd)}
-      class="px-3 py-1.5 rounded-lg text-xs font-semibold"
+      class="action-btn px-3 py-1.5 rounded-lg text-xs font-semibold"
       style="background: var(--neon-primary); color: var(--bg-deep)"
-    >+ Add Webhook</button>
+    >+ {tr($locale, "settings.add_webhook")}</button>
   </div>
 
   {#if showAdd}
     <div class="rounded-xl p-5 mb-4 space-y-3" style="background: var(--bg-surface); border: 1px solid var(--border-color)">
-      <div>
-        <label class="text-xs font-semibold mb-1 block" style="color: var(--text-secondary)">Name</label>
+      <label class="block">
+        <span class="text-xs font-semibold mb-1 block" style="color: var(--text-secondary)">Name</span>
         <input bind:value={name} type="text" placeholder="Discord Notifications"
-          class="w-full rounded-lg px-3 py-2 text-sm"
-          style="background: var(--bg-surface-2); border: 1px solid var(--border-color); color: var(--text-primary)" />
-      </div>
-      <div>
-        <label class="text-xs font-semibold mb-1 block" style="color: var(--text-secondary)">URL</label>
+          class="w-full rounded-lg px-3 py-2 text-sm" style={inputStyle} />
+      </label>
+      <label class="block">
+        <span class="text-xs font-semibold mb-1 block" style="color: var(--text-secondary)">URL</span>
         <input bind:value={url} type="url" placeholder="https://discord.com/api/webhooks/..."
-          class="w-full rounded-lg px-3 py-2 text-sm"
-          style="font-family: var(--font-mono);background: var(--bg-surface-2); border: 1px solid var(--border-color); color: var(--text-primary)" />
-      </div>
-      <div>
-        <label class="text-xs font-semibold mb-1 block" style="color: var(--text-secondary)">Secret <span class="opacity-50">(optional)</span></label>
+          class="w-full rounded-lg px-3 py-2 text-sm" style={monoInputStyle} />
+      </label>
+      <label class="block">
+        <span class="text-xs font-semibold mb-1 block" style="color: var(--text-secondary)">Secret <span class="opacity-50">(optional)</span></span>
         <input bind:value={secret} type="text" placeholder="my-secret-key"
-          class="w-full rounded-lg px-3 py-2 text-sm"
-          style="font-family: var(--font-mono);background: var(--bg-surface-2); border: 1px solid var(--border-color); color: var(--text-primary)" />
-      </div>
-      <div>
-        <label class="text-xs font-semibold mb-1 block" style="color: var(--text-secondary)">Events <span class="opacity-50">(comma-separated, * = all)</span></label>
+          class="w-full rounded-lg px-3 py-2 text-sm" style={monoInputStyle} />
+      </label>
+      <label class="block">
+        <span class="text-xs font-semibold mb-1 block" style="color: var(--text-secondary)">Events <span class="opacity-50">(comma-separated, * = all)</span></span>
         <input bind:value={events} type="text" placeholder="download.completed, download.failed"
-          class="w-full rounded-lg px-3 py-2 text-sm"
-          style="font-family: var(--font-mono);background: var(--bg-surface-2); border: 1px solid var(--border-color); color: var(--text-primary)" />
-      </div>
+          class="w-full rounded-lg px-3 py-2 text-sm" style={monoInputStyle} />
+      </label>
       <div class="flex gap-2 pt-1">
         <button onclick={handleAdd}
-          class="px-4 py-2 rounded-lg text-sm font-semibold"
+          class="action-btn px-4 py-2 rounded-lg text-sm font-semibold"
           style="background: var(--neon-primary); color: var(--bg-deep)"
-          disabled={!name.trim() || !url.trim()}>Save</button>
+          disabled={!name.trim() || !url.trim()}>{tr($locale, "common.save")}</button>
         <button onclick={() => (showAdd = false)}
           class="px-4 py-2 rounded-lg text-sm"
-          style="color: var(--text-secondary)">Cancel</button>
+          style="color: var(--text-secondary)">{tr($locale, "common.cancel")}</button>
       </div>
     </div>
   {/if}
@@ -95,7 +96,7 @@
   {#if webhooks.length === 0 && !showAdd}
     <div class="rounded-xl p-5 text-center" style="background: var(--bg-surface); border: 1px solid var(--border-color)">
       <p class="text-sm" style="color: var(--text-secondary)">
-        No webhooks configured. Add one to receive notifications on Discord, Slack, Home Assistant, etc.
+        {tr($locale, "settings.webhooks_empty")}
       </p>
     </div>
   {:else}
@@ -113,10 +114,10 @@
           <div class="flex gap-1.5 shrink-0">
             <button onclick={() => handleTest(wh.id)}
               class="px-2.5 py-1.5 rounded-lg text-xs border"
-              style="border-color: var(--border-color); color: var(--text-secondary)">Test</button>
+              style="border-color: var(--border-color); color: var(--text-secondary)">{tr($locale, "common.test")}</button>
             <button onclick={() => handleDelete(wh.id)}
               class="px-2.5 py-1.5 rounded-lg text-xs"
-              style="color: var(--neon-accent); border: 1px solid color-mix(in srgb, var(--neon-accent) 20%, transparent)">Delete</button>
+              style="color: var(--neon-accent); border: 1px solid color-mix(in srgb, var(--neon-accent) 20%, transparent)">{tr($locale, "common.delete")}</button>
           </div>
         </div>
       {/each}

--- a/web-ui/src/lib/focusTrap.ts
+++ b/web-ui/src/lib/focusTrap.ts
@@ -1,0 +1,52 @@
+// Svelte action: trap Tab focus inside a dialog/overlay and restore focus to
+// the previously focused element on teardown. Apply with `use:focusTrap` on the
+// dialog container. Keeps keyboard users from tabbing into the page behind a
+// modal and returns them to where they were when it closes (WCAG 2.4.3).
+
+const FOCUSABLE =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+export function focusTrap(node: HTMLElement) {
+  const previouslyFocused = document.activeElement as HTMLElement | null;
+
+  function focusable(): HTMLElement[] {
+    return Array.from(node.querySelectorAll<HTMLElement>(FOCUSABLE)).filter(
+      (el) => el.offsetParent !== null || el === document.activeElement,
+    );
+  }
+
+  function onKeydown(e: KeyboardEvent) {
+    if (e.key !== "Tab") return;
+    const items = focusable();
+    if (items.length === 0) {
+      e.preventDefault();
+      return;
+    }
+    const first = items[0];
+    const last = items[items.length - 1];
+    const active = document.activeElement as HTMLElement | null;
+    if (e.shiftKey && (active === first || !node.contains(active))) {
+      e.preventDefault();
+      last.focus();
+    } else if (!e.shiftKey && active === last) {
+      e.preventDefault();
+      first.focus();
+    }
+  }
+
+  // Move focus into the dialog once it's mounted, honouring an explicit
+  // [autofocus] target if present.
+  queueMicrotask(() => {
+    const target = node.querySelector<HTMLElement>("[autofocus]") ?? focusable()[0] ?? node;
+    target.focus();
+  });
+
+  node.addEventListener("keydown", onKeydown);
+
+  return {
+    destroy() {
+      node.removeEventListener("keydown", onKeydown);
+      previouslyFocused?.focus?.();
+    },
+  };
+}

--- a/web-ui/src/lib/i18n.ts
+++ b/web-ui/src/lib/i18n.ts
@@ -3,6 +3,8 @@ import { writable, get } from "svelte/store";
 
 export type Locale = "en" | "de";
 
+export type TParams = Record<string, string | number>;
+
 const translations: Record<Locale, Record<string, string>> = {
   en: {
     "nav.downloads": "Downloads",
@@ -16,16 +18,82 @@ const translations: Record<Locale, Record<string, string>> = {
     "sidebar.queued": "Queued",
     "sidebar.done": "Done",
     "sidebar.limit": "Limit",
-    "settings.appearance": "Appearance",
-    "settings.downloads": "Downloads",
-    "settings.webhooks": "Webhooks",
-    "settings.language": "Language",
-    "settings.about": "About",
-    "settings.saved": "Settings saved",
+
+    // Common
+    "common.save": "Save",
+    "common.cancel": "Cancel",
+    "common.add": "Add",
+    "common.test": "Test",
+    "common.delete": "Delete",
+    "common.close": "Close",
+    "common.adding": "Adding…",
+    "common.saving": "Saving…",
+    "common.on": "On",
+    "common.off": "Off",
+
+    // Add panel
+    "add.title": "Add Download",
+    "add.tab_url": "URL / Links",
+    "add.tab_file": "File (NZB / DLC)",
+    "add.placeholder": "Paste URL(s) here — one per line",
+    "add.hint": "Ctrl+Enter to submit. Multiple URLs supported (one per line).",
+    "add.submit": "Add Download",
+    "add.links_one": "1 link detected",
+    "add.links_many": "{count} links detected",
+    "add.links_invalid": "{count} line(s) don't look like URLs",
+    "add.drop_hint": "Drop file here or click to browse",
+    "add.file_types": "NZB, DLC, or text file with URLs",
+    "add.added": "Download added",
+    "add.added_many": "{count} downloads added",
+    "add.failed": "Failed to add download",
+    "add.file_imported": "File imported",
+    "add.file_failed": "Failed to import file",
+
+    // Downloads page
     "downloads.search": "Search downloads...",
     "downloads.no_downloads": "No downloads yet",
     "downloads.add_first": "Add your first download",
+    "downloads.add_hint": "Ctrl+N to add · Drag & drop supported",
     "downloads.selected": "selected",
+    "downloads.select_all": "Select all",
+    "downloads.clear_selection": "Clear selection",
+    "downloads.sort_by": "Sort by",
+    "downloads.grid_view": "Grid view",
+    "downloads.list_view": "List view",
+    "downloads.more": "More options",
+
+    "filter.all": "All",
+    "filter.downloading": "Downloading",
+    "filter.queued": "Queued",
+    "filter.paused": "Paused",
+    "filter.completed": "Completed",
+    "filter.failed": "Failed",
+    "sort.status": "Status",
+    "sort.name": "Name",
+    "sort.size": "Size",
+    "sort.date": "Date",
+
+    // Empty states per filter
+    "empty.downloading": "Nothing downloading right now",
+    "empty.queued": "The queue is empty",
+    "empty.paused": "No paused downloads",
+    "empty.completed": "No completed downloads yet",
+    "empty.failed": "No failed downloads — nice.",
+    "empty.search": "No downloads match your search",
+
+    // Batch
+    "batch.pause": "Pause",
+    "batch.resume": "Resume",
+    "batch.delete": "Delete",
+    "batch.confirm": "Sure?",
+    "batch.paused": "Paused {count} downloads",
+    "batch.resumed": "Resumed {count} downloads",
+    "batch.deleted": "Deleted {count} downloads",
+    "batch.paused_partial": "Paused {done}/{total} downloads ({failed} failed)",
+    "batch.resumed_partial": "Resumed {done}/{total} downloads ({failed} failed)",
+    "batch.deleted_partial": "Deleted {done}/{total} downloads ({failed} failed)",
+
+    // Actions
     "action.pause": "Pause",
     "action.resume": "Resume",
     "action.delete": "Delete",
@@ -33,17 +101,91 @@ const translations: Record<Locale, Record<string, string>> = {
     "action.report": "Report",
     "action.sure": "Sure?",
     "action.copy_url": "URL copied",
+    "action.copy_failed": "Failed to copy",
+    "action.open_browser": "Open in Browser",
+    "action.copy": "Copy URL",
+    "action.undo": "Undo",
+
+    // Status
     "status.downloading": "downloading",
     "status.completed": "completed",
     "status.failed": "failed",
     "status.paused": "paused",
     "status.queued": "queued",
+
+    // Toasts
     "toast.download_complete": "Download complete",
     "toast.download_failed": "Download failed",
+    "toast.deleted_one": "Download deleted",
+
+    // History
     "history.empty": "No download history yet",
     "history.empty_hint": "Completed downloads will appear here",
+
+    // Connection
     "connection.online": "Connected",
     "connection.offline": "Offline",
+
+    // Captcha
+    "captcha.title": "Solve Captcha",
+    "captcha.enter": "Enter the characters you see",
+    "captcha.solve": "Solve",
+    "captcha.skip": "Skip",
+    "captcha.time_left": "{seconds}s left",
+    "captcha.solved": "Captcha submitted",
+    "captcha.expired": "Captcha expired",
+
+    // Settings — appearance
+    "settings.appearance": "Appearance",
+    "settings.theme": "Theme",
+    "theme.dark": "Dark",
+    "theme.light": "Light",
+    "settings.color_palette": "Color Palette",
+    "settings.neon_intensity": "Neon Intensity",
+
+    // Settings — downloads
+    "settings.downloads": "Downloads",
+    "settings.download_dir": "Download Directory",
+    "settings.max_concurrent": "Max Concurrent Downloads",
+    "settings.speed_limit": "Global Speed Limit",
+    "settings.speed_limit_hint": "B/s (0 = unlimited)",
+    "settings.retry_behavior": "Retry Behavior",
+    "settings.max_retries": "Max retries before giving up",
+    "settings.initial_delay": "Initial delay (s)",
+    "settings.max_delay": "Max delay (s)",
+
+    // Settings — webhooks
+    "settings.webhooks": "Webhooks",
+    "settings.add_webhook": "Add Webhook",
+    "settings.webhooks_empty":
+      "No webhooks configured. Add one to receive notifications on Discord, Slack, Home Assistant, etc.",
+
+    // Settings — misc
+    "settings.language": "Language",
+    "settings.about": "About",
+    "settings.saved": "Settings saved",
+    "settings.save_failed": "Failed to save settings",
+
+    // Command palette
+    "cmd.placeholder": "Type a command or search…",
+    "cmd.no_results": "No matching commands",
+    "cmd.group_navigate": "Navigate",
+    "cmd.group_actions": "Actions",
+    "cmd.group_appearance": "Appearance",
+    "cmd.add_download": "Add download",
+    "cmd.toggle_theme": "Toggle light / dark",
+    "cmd.show_shortcuts": "Show keyboard shortcuts",
+    "cmd.set_palette": "Palette: {name}",
+    "cmd.set_intensity": "Neon intensity: {name}",
+    "cmd.hint_open": "Open command palette",
+
+    // Shortcuts
+    "shortcuts.title": "Keyboard Shortcuts",
+    "shortcuts.command_palette": "Command palette",
+    "shortcuts.add": "Add download",
+    "shortcuts.close": "Close panel / dialog",
+    "shortcuts.navigate": "Navigate pages",
+    "shortcuts.help": "Show this help",
   },
   de: {
     "nav.downloads": "Downloads",
@@ -57,16 +199,76 @@ const translations: Record<Locale, Record<string, string>> = {
     "sidebar.queued": "Warteschl.",
     "sidebar.done": "Fertig",
     "sidebar.limit": "Limit",
-    "settings.appearance": "Erscheinungsbild",
-    "settings.downloads": "Downloads",
-    "settings.webhooks": "Webhooks",
-    "settings.language": "Sprache",
-    "settings.about": "Über",
-    "settings.saved": "Einstellungen gespeichert",
+
+    "common.save": "Speichern",
+    "common.cancel": "Abbrechen",
+    "common.add": "Hinzufügen",
+    "common.test": "Testen",
+    "common.delete": "Löschen",
+    "common.close": "Schließen",
+    "common.adding": "Wird hinzugefügt…",
+    "common.saving": "Wird gespeichert…",
+    "common.on": "An",
+    "common.off": "Aus",
+
+    "add.title": "Download hinzufügen",
+    "add.tab_url": "URL / Links",
+    "add.tab_file": "Datei (NZB / DLC)",
+    "add.placeholder": "URL(s) hier einfügen — eine pro Zeile",
+    "add.hint": "Strg+Enter zum Absenden. Mehrere URLs möglich (eine pro Zeile).",
+    "add.submit": "Download hinzufügen",
+    "add.links_one": "1 Link erkannt",
+    "add.links_many": "{count} Links erkannt",
+    "add.links_invalid": "{count} Zeile(n) sehen nicht wie URLs aus",
+    "add.drop_hint": "Datei hierher ziehen oder klicken zum Auswählen",
+    "add.file_types": "NZB, DLC oder Textdatei mit URLs",
+    "add.added": "Download hinzugefügt",
+    "add.added_many": "{count} Downloads hinzugefügt",
+    "add.failed": "Download konnte nicht hinzugefügt werden",
+    "add.file_imported": "Datei importiert",
+    "add.file_failed": "Datei konnte nicht importiert werden",
+
     "downloads.search": "Downloads durchsuchen...",
     "downloads.no_downloads": "Noch keine Downloads",
     "downloads.add_first": "Ersten Download hinzufügen",
+    "downloads.add_hint": "Strg+N zum Hinzufügen · Drag & Drop unterstützt",
     "downloads.selected": "ausgewählt",
+    "downloads.select_all": "Alle auswählen",
+    "downloads.clear_selection": "Auswahl aufheben",
+    "downloads.sort_by": "Sortieren nach",
+    "downloads.grid_view": "Kachelansicht",
+    "downloads.list_view": "Listenansicht",
+    "downloads.more": "Weitere Optionen",
+
+    "filter.all": "Alle",
+    "filter.downloading": "Lädt",
+    "filter.queued": "Warteschlange",
+    "filter.paused": "Pausiert",
+    "filter.completed": "Fertig",
+    "filter.failed": "Fehler",
+    "sort.status": "Status",
+    "sort.name": "Name",
+    "sort.size": "Größe",
+    "sort.date": "Datum",
+
+    "empty.downloading": "Gerade läuft kein Download",
+    "empty.queued": "Die Warteschlange ist leer",
+    "empty.paused": "Keine pausierten Downloads",
+    "empty.completed": "Noch keine abgeschlossenen Downloads",
+    "empty.failed": "Keine fehlgeschlagenen Downloads — sehr gut.",
+    "empty.search": "Keine Downloads passen zur Suche",
+
+    "batch.pause": "Pause",
+    "batch.resume": "Fortsetzen",
+    "batch.delete": "Löschen",
+    "batch.confirm": "Sicher?",
+    "batch.paused": "{count} Downloads pausiert",
+    "batch.resumed": "{count} Downloads fortgesetzt",
+    "batch.deleted": "{count} Downloads gelöscht",
+    "batch.paused_partial": "{done}/{total} Downloads pausiert ({failed} fehlgeschlagen)",
+    "batch.resumed_partial": "{done}/{total} Downloads fortgesetzt ({failed} fehlgeschlagen)",
+    "batch.deleted_partial": "{done}/{total} Downloads gelöscht ({failed} fehlgeschlagen)",
+
     "action.pause": "Pause",
     "action.resume": "Fortsetzen",
     "action.delete": "Löschen",
@@ -74,19 +276,89 @@ const translations: Record<Locale, Record<string, string>> = {
     "action.report": "Melden",
     "action.sure": "Sicher?",
     "action.copy_url": "URL kopiert",
+    "action.copy_failed": "Kopieren fehlgeschlagen",
+    "action.open_browser": "Im Browser öffnen",
+    "action.copy": "URL kopieren",
+    "action.undo": "Rückgängig",
+
     "status.downloading": "Lädt",
     "status.completed": "Fertig",
     "status.failed": "Fehler",
     "status.paused": "Pausiert",
     "status.queued": "Warteschl.",
+
     "toast.download_complete": "Download abgeschlossen",
     "toast.download_failed": "Download fehlgeschlagen",
+    "toast.deleted_one": "Download gelöscht",
+
     "history.empty": "Noch kein Download-Verlauf",
     "history.empty_hint": "Abgeschlossene Downloads erscheinen hier",
+
     "connection.online": "Verbunden",
     "connection.offline": "Offline",
+
+    "captcha.title": "Captcha lösen",
+    "captcha.enter": "Gib die angezeigten Zeichen ein",
+    "captcha.solve": "Lösen",
+    "captcha.skip": "Überspringen",
+    "captcha.time_left": "{seconds}s übrig",
+    "captcha.solved": "Captcha übermittelt",
+    "captcha.expired": "Captcha abgelaufen",
+
+    "settings.appearance": "Erscheinungsbild",
+    "settings.theme": "Design",
+    "theme.dark": "Dunkel",
+    "theme.light": "Hell",
+    "settings.color_palette": "Farbpalette",
+    "settings.neon_intensity": "Neon-Intensität",
+
+    "settings.downloads": "Downloads",
+    "settings.download_dir": "Download-Verzeichnis",
+    "settings.max_concurrent": "Max. gleichzeitige Downloads",
+    "settings.speed_limit": "Globales Geschwindigkeitslimit",
+    "settings.speed_limit_hint": "B/s (0 = unbegrenzt)",
+    "settings.retry_behavior": "Wiederholungsverhalten",
+    "settings.max_retries": "Max. Versuche vor Abbruch",
+    "settings.initial_delay": "Anfangsverzögerung (s)",
+    "settings.max_delay": "Max. Verzögerung (s)",
+
+    "settings.webhooks": "Webhooks",
+    "settings.add_webhook": "Webhook hinzufügen",
+    "settings.webhooks_empty":
+      "Keine Webhooks konfiguriert. Füge einen hinzu, um Benachrichtigungen auf Discord, Slack, Home Assistant usw. zu erhalten.",
+
+    "settings.language": "Sprache",
+    "settings.about": "Über",
+    "settings.saved": "Einstellungen gespeichert",
+    "settings.save_failed": "Einstellungen konnten nicht gespeichert werden",
+
+    "cmd.placeholder": "Befehl eingeben oder suchen…",
+    "cmd.no_results": "Keine passenden Befehle",
+    "cmd.group_navigate": "Navigation",
+    "cmd.group_actions": "Aktionen",
+    "cmd.group_appearance": "Erscheinungsbild",
+    "cmd.add_download": "Download hinzufügen",
+    "cmd.toggle_theme": "Hell / Dunkel umschalten",
+    "cmd.show_shortcuts": "Tastenkürzel anzeigen",
+    "cmd.set_palette": "Palette: {name}",
+    "cmd.set_intensity": "Neon-Intensität: {name}",
+    "cmd.hint_open": "Befehlspalette öffnen",
+
+    "shortcuts.title": "Tastenkürzel",
+    "shortcuts.command_palette": "Befehlspalette",
+    "shortcuts.add": "Download hinzufügen",
+    "shortcuts.close": "Panel / Dialog schließen",
+    "shortcuts.navigate": "Seiten wechseln",
+    "shortcuts.help": "Diese Hilfe anzeigen",
   },
 };
+
+function interpolate(str: string, params?: TParams): string {
+  if (!params) return str;
+  return str.replace(/\{(\w+)\}/g, (_, k) =>
+    k in params ? String(params[k]) : `{${k}}`,
+  );
+}
 
 function createLocaleStore() {
   const stored = typeof localStorage !== "undefined" ? localStorage.getItem("locale") : null;
@@ -103,12 +375,14 @@ function createLocaleStore() {
 
 export const locale = createLocaleStore();
 
-export function t(key: string): string {
+export function t(key: string, params?: TParams): string {
   const lang = get(locale);
-  return translations[lang]?.[key] ?? translations.en[key] ?? key;
+  const str = translations[lang]?.[key] ?? translations.en[key] ?? key;
+  return interpolate(str, params);
 }
 
-// Reactive version for Svelte components
-export function tr(lang: Locale, key: string): string {
-  return translations[lang]?.[key] ?? translations.en[key] ?? key;
+// Reactive version for Svelte components — pass the `$locale` store value.
+export function tr(lang: Locale, key: string, params?: TParams): string {
+  const str = translations[lang]?.[key] ?? translations.en[key] ?? key;
+  return interpolate(str, params);
 }

--- a/web-ui/src/lib/i18n.ts
+++ b/web-ui/src/lib/i18n.ts
@@ -117,6 +117,42 @@ const translations: Record<Locale, Record<string, string>> = {
     "toast.download_complete": "Download complete",
     "toast.download_failed": "Download failed",
     "toast.deleted_one": "Download deleted",
+    "toast.delete_failed": "Failed to delete download",
+
+    // Side panel
+    "panel.details": "Download Details",
+
+    // Neon intensity labels (also used in the command palette)
+    "intensity.off": "Off",
+    "intensity.low": "Low",
+    "intensity.mid": "Mid",
+    "intensity.high": "High",
+    "intensity.full": "Full",
+
+    // Webhook form labels + toasts
+    "webhook.name": "Name",
+    "webhook.url": "URL",
+    "webhook.secret": "Secret",
+    "webhook.optional": "optional",
+    "webhook.events": "Events",
+    "webhook.events_hint": "comma-separated, * = all",
+    "webhook.added": "Webhook added",
+    "webhook.add_failed": "Failed to add webhook",
+    "webhook.removed": "Webhook removed",
+    "webhook.delete_failed": "Failed to delete webhook",
+    "webhook.test_sent": "Test sent",
+    "webhook.test_failed": "Test failed",
+    "webhook.signed": "signed",
+
+    // Feedback dialog
+    "feedback.title": "Feedback",
+    "feedback.crash_reported": "Crash auto-reported",
+    "feedback.view_issue": "View issue",
+    "feedback.report_bug": "Report a Bug",
+    "feedback.request_feature": "Request a Feature",
+    "feedback.opens_github": "Opens GitHub with pre-filled template",
+    "feedback.auto_on": "Crashes are automatically reported.",
+    "feedback.auto_off": "Set AMIGO_GITHUB_TOKEN for automatic crash reporting.",
 
     // History
     "history.empty": "No download history yet",
@@ -291,6 +327,38 @@ const translations: Record<Locale, Record<string, string>> = {
     "toast.download_complete": "Download abgeschlossen",
     "toast.download_failed": "Download fehlgeschlagen",
     "toast.deleted_one": "Download gelöscht",
+    "toast.delete_failed": "Download konnte nicht gelöscht werden",
+
+    "panel.details": "Download-Details",
+
+    "intensity.off": "Aus",
+    "intensity.low": "Niedrig",
+    "intensity.mid": "Mittel",
+    "intensity.high": "Hoch",
+    "intensity.full": "Voll",
+
+    "webhook.name": "Name",
+    "webhook.url": "URL",
+    "webhook.secret": "Geheimnis",
+    "webhook.optional": "optional",
+    "webhook.events": "Ereignisse",
+    "webhook.events_hint": "kommagetrennt, * = alle",
+    "webhook.added": "Webhook hinzugefügt",
+    "webhook.add_failed": "Webhook konnte nicht hinzugefügt werden",
+    "webhook.removed": "Webhook entfernt",
+    "webhook.delete_failed": "Webhook konnte nicht gelöscht werden",
+    "webhook.test_sent": "Test gesendet",
+    "webhook.test_failed": "Test fehlgeschlagen",
+    "webhook.signed": "signiert",
+
+    "feedback.title": "Feedback",
+    "feedback.crash_reported": "Absturz automatisch gemeldet",
+    "feedback.view_issue": "Issue ansehen",
+    "feedback.report_bug": "Fehler melden",
+    "feedback.request_feature": "Funktion vorschlagen",
+    "feedback.opens_github": "Öffnet GitHub mit vorausgefülltem Template",
+    "feedback.auto_on": "Abstürze werden automatisch gemeldet.",
+    "feedback.auto_off": "AMIGO_GITHUB_TOKEN setzen für automatische Absturzberichte.",
 
     "history.empty": "Noch kein Download-Verlauf",
     "history.empty_hint": "Abgeschlossene Downloads erscheinen hier",

--- a/web-ui/src/lib/i18n.ts
+++ b/web-ui/src/lib/i18n.ts
@@ -133,7 +133,8 @@ const translations: Record<Locale, Record<string, string>> = {
     "captcha.skip": "Skip",
     "captcha.time_left": "{seconds}s left",
     "captcha.solved": "Captcha submitted",
-    "captcha.expired": "Captcha expired",
+    "captcha.failed": "Failed to submit captcha",
+    "captcha.expired": "Captcha timed out",
 
     // Settings — appearance
     "settings.appearance": "Appearance",
@@ -303,7 +304,8 @@ const translations: Record<Locale, Record<string, string>> = {
     "captcha.skip": "Überspringen",
     "captcha.time_left": "{seconds}s übrig",
     "captcha.solved": "Captcha übermittelt",
-    "captcha.expired": "Captcha abgelaufen",
+    "captcha.failed": "Captcha konnte nicht übermittelt werden",
+    "captcha.expired": "Captcha-Zeit abgelaufen",
 
     "settings.appearance": "Erscheinungsbild",
     "settings.theme": "Design",

--- a/web-ui/src/lib/motion.ts
+++ b/web-ui/src/lib/motion.ts
@@ -1,0 +1,42 @@
+// Shared motion helpers — keep list/transition feel consistent and always
+// honour the user's reduced-motion preference (mirrors the global CSS guard
+// in tokens.css so JS-driven Svelte transitions are suppressed too).
+import { cubicOut } from "svelte/easing";
+import type { TransitionConfig } from "svelte/transition";
+
+export function prefersReducedMotion(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches
+  );
+}
+
+/**
+ * Shared `animate:flip` config for lists. Filter/sort/reorder changes glide
+ * to their new position instead of jumping. Distance-aware duration, capped so
+ * long moves still feel snappy. Collapses to 0 under reduced-motion.
+ */
+export const flipConfig = {
+  duration: (len: number) => (prefersReducedMotion() ? 0 : Math.min(420, 160 + len * 0.4)),
+  easing: cubicOut,
+};
+
+/** Combined scale + fade — the house transition for popovers, menus, cards. */
+export function scaleFade(
+  _node: Element,
+  { duration = 200, start = 0.96, y = 0 }: { duration?: number; start?: number; y?: number } = {},
+): TransitionConfig {
+  if (prefersReducedMotion()) return { duration: 0 };
+  return {
+    duration,
+    easing: cubicOut,
+    css: (t) =>
+      `opacity: ${t}; transform: translateY(${(1 - t) * y}px) scale(${start + (1 - start) * t});`,
+  };
+}
+
+/** Reduced-motion-aware duration for `fly`/`slide` params. */
+export function dur(ms: number): number {
+  return prefersReducedMotion() ? 0 : ms;
+}

--- a/web-ui/src/lib/stores.ts
+++ b/web-ui/src/lib/stores.ts
@@ -280,7 +280,11 @@ export function attachRouterPopstateListener(): () => void {
 export const downloads = writable<Download[]>([]);
 export const selectedDownloadId = writable<string | null>(null);
 
-/** Flips true after the first successful downloads fetch — drives skeletons. */
+/**
+ * Flips true after the first downloads fetch *attempt* completes (success or
+ * failure). Drives skeleton gating: once an attempt has finished, the Downloads
+ * page shows real data or its empty/offline state rather than skeletons forever.
+ */
 export const downloadsLoaded = writable<boolean>(false);
 
 export const selectedDownload = derived(

--- a/web-ui/src/lib/stores.ts
+++ b/web-ui/src/lib/stores.ts
@@ -280,6 +280,9 @@ export function attachRouterPopstateListener(): () => void {
 export const downloads = writable<Download[]>([]);
 export const selectedDownloadId = writable<string | null>(null);
 
+/** Flips true after the first successful downloads fetch — drives skeletons. */
+export const downloadsLoaded = writable<boolean>(false);
+
 export const selectedDownload = derived(
   [downloads, selectedDownloadId],
   ([$downloads, $id]) => $id ? $downloads.find((d) => d.id === $id) ?? null : null

--- a/web-ui/src/lib/toast.ts
+++ b/web-ui/src/lib/toast.ts
@@ -1,24 +1,76 @@
-import { writable } from "svelte/store";
+import { writable, get } from "svelte/store";
+
+export interface ToastAction {
+  label: string;
+  onAction: () => void;
+}
 
 export interface Toast {
   id: number;
   type: "success" | "error" | "info";
   title: string;
   message?: string;
+  action?: ToastAction;
+  /** Auto-dismiss delay in ms. 0 keeps the toast until dismissed. */
+  duration: number;
 }
 
+export interface ToastOptions {
+  action?: ToastAction;
+  /** Override the auto-dismiss delay (ms). 0 = sticky. */
+  duration?: number;
+}
+
+// Errors linger longer than successes — they usually carry something to read.
+const DEFAULT_DURATIONS: Record<Toast["type"], number> = {
+  success: 5000,
+  info: 5000,
+  error: 9000,
+};
+
 let nextId = 0;
+const timers = new Map<number, ReturnType<typeof setTimeout>>();
 
 export const toasts = writable<Toast[]>([]);
 
-export function addToast(type: Toast["type"], title: string, message?: string) {
+export function addToast(
+  type: Toast["type"],
+  title: string,
+  message?: string,
+  opts?: ToastOptions,
+): number {
   const id = nextId++;
-  toasts.update((t) => [...t, { id, type, title, message }]);
+  const duration = opts?.duration ?? DEFAULT_DURATIONS[type];
+  toasts.update((t) => [...t, { id, type, title, message, action: opts?.action, duration }]);
+  if (duration > 0) scheduleRemoval(id, duration);
+  return id;
+}
 
-  // Auto-remove after 5s
-  setTimeout(() => removeToast(id), 5000);
+function scheduleRemoval(id: number, ms: number) {
+  clearTimeout(timers.get(id));
+  timers.set(
+    id,
+    setTimeout(() => removeToast(id), ms),
+  );
+}
+
+/** Pause auto-dismiss (e.g. while the pointer hovers the toast). */
+export function pauseToast(id: number) {
+  const timer = timers.get(id);
+  if (timer) {
+    clearTimeout(timer);
+    timers.delete(id);
+  }
+}
+
+/** Resume auto-dismiss using the toast's configured duration. */
+export function resumeToast(id: number) {
+  const toast = get(toasts).find((t) => t.id === id);
+  if (toast && toast.duration > 0) scheduleRemoval(id, toast.duration);
 }
 
 export function removeToast(id: number) {
+  clearTimeout(timers.get(id));
+  timers.delete(id);
   toasts.update((t) => t.filter((toast) => toast.id !== id));
 }

--- a/web-ui/src/pages/Downloads.svelte
+++ b/web-ui/src/pages/Downloads.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { flip } from "svelte/animate";
-  import { pauseDownload, resumeDownload, deleteDownload } from "../lib/api";
+  import { pauseDownload, resumeDownload, deleteDownload, addBatch } from "../lib/api";
   import {
     downloads, usenetDownloads, protocolFilter, openAddPanel,
     selectedIds, toggleSelection, clearSelection, selectAll,
@@ -112,6 +112,9 @@
     }
     confirmingBatchDelete = false;
     const total = $selectedIds.size;
+    // Capture URLs up front so deletion can be undone (re-queues them).
+    const byId = new Map(allDownloads().map((d) => [d.id, d.url]));
+    const urls = [...$selectedIds].map((id) => byId.get(id)).filter((u): u is string => !!u);
     let failed = 0;
     for (const id of $selectedIds) {
       try { await deleteDownload(id); } catch { failed++; }
@@ -119,7 +122,11 @@
     addToast(failed ? "error" : "info",
       failed
         ? tr($locale, "batch.deleted_partial", { done: total - failed, total, failed })
-        : tr($locale, "batch.deleted", { count: total }));
+        : tr($locale, "batch.deleted", { count: total }),
+      undefined,
+      urls.length > 0
+        ? { action: { label: tr($locale, "action.undo"), onAction: () => addBatch(urls) } }
+        : undefined);
     clearSelection();
   }
 

--- a/web-ui/src/pages/Downloads.svelte
+++ b/web-ui/src/pages/Downloads.svelte
@@ -1,15 +1,18 @@
 <script lang="ts">
+  import { flip } from "svelte/animate";
   import { pauseDownload, resumeDownload, deleteDownload } from "../lib/api";
   import {
     downloads, usenetDownloads, protocolFilter, openAddPanel,
     selectedIds, toggleSelection, clearSelection, selectAll,
-    searchQuery,
+    searchQuery, downloadsLoaded,
   } from "../lib/stores";
   import { addToast } from "../lib/toast";
+  import { locale, tr } from "../lib/i18n";
+  import { flipConfig } from "../lib/motion";
   import DownloadCard from "../components/DownloadCard.svelte";
   import DownloadCompactRow from "../components/DownloadCompactRow.svelte";
+  import SkeletonCard from "../components/SkeletonCard.svelte";
   import Icon from "@amigo/ui/components/Icon.svelte";
-
 
   let filter = $state<string>("all");
   let confirmingBatchDelete = $state(false);
@@ -33,12 +36,7 @@
   };
 
   const filters = ["all", "downloading", "queued", "paused", "completed", "failed"];
-  const sortOptions = [
-    { value: "status", label: "Status" },
-    { value: "name", label: "Name" },
-    { value: "size", label: "Size" },
-    { value: "date", label: "Date" },
-  ];
+  const sortOptions = ["status", "name", "size", "date"];
 
   // Merge HTTP + Usenet downloads based on protocol filter
   let allDownloads = $derived(() => {
@@ -65,6 +63,8 @@
   );
 
   let batchMode = $derived($selectedIds.size > 0);
+  // Show skeletons only on the very first load, before any data has arrived.
+  let showSkeleton = $derived(!$downloadsLoaded && allDownloads().length === 0);
 
   function countByStatus(status: string): number {
     return allDownloads().filter((d) => d.status === status).length;
@@ -84,7 +84,10 @@
     for (const id of $selectedIds) {
       try { await pauseDownload(id); } catch { failed++; }
     }
-    addToast(failed ? "error" : "info", failed ? `Paused ${total - failed}/${total} downloads (${failed} failed)` : `Paused ${total} downloads`);
+    addToast(failed ? "error" : "info",
+      failed
+        ? tr($locale, "batch.paused_partial", { done: total - failed, total, failed })
+        : tr($locale, "batch.paused", { count: total }));
     clearSelection();
   }
 
@@ -94,7 +97,10 @@
     for (const id of $selectedIds) {
       try { await resumeDownload(id); } catch { failed++; }
     }
-    addToast(failed ? "error" : "info", failed ? `Resumed ${total - failed}/${total} downloads (${failed} failed)` : `Resumed ${total} downloads`);
+    addToast(failed ? "error" : "info",
+      failed
+        ? tr($locale, "batch.resumed_partial", { done: total - failed, total, failed })
+        : tr($locale, "batch.resumed", { count: total }));
     clearSelection();
   }
 
@@ -110,9 +116,18 @@
     for (const id of $selectedIds) {
       try { await deleteDownload(id); } catch { failed++; }
     }
-    addToast(failed ? "error" : "info", failed ? `Deleted ${total - failed}/${total} downloads (${failed} failed)` : `Deleted ${total} downloads`);
+    addToast(failed ? "error" : "info",
+      failed
+        ? tr($locale, "batch.deleted_partial", { done: total - failed, total, failed })
+        : tr($locale, "batch.deleted", { count: total }));
     clearSelection();
   }
+
+  // Empty-state copy depends on context: searching, a specific filter, or the
+  // genuine first-run state (filter "all", nothing at all).
+  let emptyKey = $derived(
+    $searchQuery ? "empty.search" : filter !== "all" ? `empty.${filter}` : ""
+  );
 
   function handleDragStart(id: string) {
     return (e: DragEvent) => {
@@ -150,156 +165,186 @@
 </script>
 
 <div class="space-y-4">
-  <!-- Search bar + sort + view toggle -->
-  <div class="flex gap-2 items-center">
-    <div class="flex-1 flex items-center gap-2 rounded-lg px-3 py-2" style="background: var(--bg-surface); border: 1px solid var(--border-color)">
-      <Icon name="search" size={16} />
-      <input
-        type="text"
-        placeholder="Search downloads..."
-        bind:value={$searchQuery}
-        class="flex-1 bg-transparent text-sm outline-none"
-        style="color: var(--text-primary)"
-        aria-label="Search downloads"
-      />
-      {#if $searchQuery}
-        <button onclick={() => searchQuery.set("")} class="icon-btn p-0.5 rounded" style="color: var(--text-secondary)" aria-label="Clear search">
-          <Icon name="x" size={14} />
+  <!-- Sticky toolbar: search + sort + view + filters stay in reach while scrolling -->
+  <div class="toolbar-sticky space-y-3 -mx-1 px-1 pt-1 pb-2">
+    <div class="flex gap-2 items-center flex-wrap">
+      <div class="flex-1 min-w-[12rem] flex items-center gap-2 rounded-lg px-3 py-2" style="background: var(--bg-surface); border: 1px solid var(--border-color)">
+        <Icon name="search" size={16} />
+        <input
+          type="text"
+          placeholder={tr($locale, "downloads.search")}
+          bind:value={$searchQuery}
+          class="flex-1 bg-transparent text-sm outline-none min-w-0"
+          style="color: var(--text-primary)"
+          aria-label={tr($locale, "downloads.search")}
+        />
+        {#if $searchQuery}
+          <button onclick={() => searchQuery.set("")} class="icon-btn p-0.5 rounded" style="color: var(--text-secondary)" aria-label={tr($locale, "common.close")}>
+            <Icon name="x" size={14} />
+          </button>
+        {/if}
+      </div>
+
+      <!-- Sort -->
+      <div class="flex items-center gap-1 rounded-lg px-2 py-1.5 shrink-0" style="background: var(--bg-surface); border: 1px solid var(--border-color)">
+        <Icon name="sort" size={14} />
+        <select
+          bind:value={sortBy}
+          class="bg-transparent text-xs outline-none cursor-pointer"
+          style="color: var(--text-primary)"
+          aria-label={tr($locale, "downloads.sort_by")}
+        >
+          {#each sortOptions as opt}
+            <option value={opt} style="background: var(--bg-surface-2)">{tr($locale, `sort.${opt}`)}</option>
+          {/each}
+        </select>
+      </div>
+
+      <!-- View toggle -->
+      <div class="flex shrink-0 rounded-lg overflow-hidden" style="border: 1px solid var(--border-color)">
+        <button
+          onclick={() => setViewMode("grid")}
+          class="icon-btn p-2"
+          aria-pressed={viewMode === "grid"}
+          style="color: {viewMode === 'grid' ? 'var(--neon-primary)' : 'var(--text-secondary)'}; background: {viewMode === 'grid' ? 'var(--hover-bg)' : 'var(--bg-surface)'}"
+          aria-label={tr($locale, "downloads.grid_view")}
+        >
+          <Icon name="grid" size={14} />
+        </button>
+        <button
+          onclick={() => setViewMode("list")}
+          class="icon-btn p-2"
+          aria-pressed={viewMode === "list"}
+          style="color: {viewMode === 'list' ? 'var(--neon-primary)' : 'var(--text-secondary)'}; background: {viewMode === 'list' ? 'var(--hover-bg)' : 'var(--bg-surface)'}"
+          aria-label={tr($locale, "downloads.list_view")}
+        >
+          <Icon name="list" size={14} />
+        </button>
+      </div>
+    </div>
+
+    <!-- Filter chips (horizontally scrollable on narrow screens) + batch toggle -->
+    <div class="flex items-center gap-2">
+      <div role="radiogroup" aria-label="Filter by status" class="chip-rail flex gap-2 flex-1 overflow-x-auto">
+        {#each filters as f}
+          <button
+            role="radio"
+            aria-checked={filter === f}
+            onclick={() => (filter = f)}
+            class="filter-chip px-3 py-1.5 rounded-lg text-sm font-medium shrink-0"
+            style={filter === f
+              ? "background: color-mix(in srgb, var(--neon-primary) 15%, transparent); color: var(--neon-primary)"
+              : "background: var(--bg-surface); color: var(--text-secondary)"}
+          >
+            {tr($locale, `filter.${f}`)}
+            <span class="ml-1 tabular-nums opacity-50">{f === "all" ? allDownloads().length : countByStatus(f)}</span>
+          </button>
+        {/each}
+      </div>
+
+      {#if filtered.length > 0}
+        <button
+          onclick={handleSelectAll}
+          class="filter-chip px-3 py-1.5 rounded-lg text-sm font-medium shrink-0 flex items-center"
+          style={batchMode
+            ? "background: color-mix(in srgb, var(--neon-primary) 15%, transparent); color: var(--neon-primary)"
+            : "background: var(--bg-surface); color: var(--text-secondary)"}
+          aria-label={tr($locale, "downloads.select_all")}
+        >
+          <Icon name="check" size={14} />
+          {#if batchMode}<span class="ml-1 tabular-nums">{$selectedIds.size}</span>{/if}
         </button>
       {/if}
     </div>
-
-    <!-- Sort -->
-    <div class="flex items-center gap-1 rounded-lg px-2 py-1.5 shrink-0" style="background: var(--bg-surface); border: 1px solid var(--border-color)">
-      <Icon name="sort" size={14} />
-      <select
-        bind:value={sortBy}
-        class="bg-transparent text-xs outline-none cursor-pointer"
-        style="color: var(--text-primary)"
-        aria-label="Sort by"
-      >
-        {#each sortOptions as opt}
-          <option value={opt.value} style="background: var(--bg-surface-2)">{opt.label}</option>
-        {/each}
-      </select>
-    </div>
-
-    <!-- View toggle -->
-    <div class="flex shrink-0 rounded-lg overflow-hidden" style="border: 1px solid var(--border-color)">
-      <button
-        onclick={() => setViewMode("grid")}
-        class="icon-btn p-2"
-        style="color: {viewMode === 'grid' ? 'var(--neon-primary)' : 'var(--text-secondary)'}; background: {viewMode === 'grid' ? 'var(--hover-bg)' : 'var(--bg-surface)'}"
-        aria-label="Grid view"
-      >
-        <Icon name="grid" size={14} />
-      </button>
-      <button
-        onclick={() => setViewMode("list")}
-        class="icon-btn p-2"
-        style="color: {viewMode === 'list' ? 'var(--neon-primary)' : 'var(--text-secondary)'}; background: {viewMode === 'list' ? 'var(--hover-bg)' : 'var(--bg-surface)'}"
-        aria-label="List view"
-      >
-        <Icon name="list" size={14} />
-      </button>
-    </div>
-  </div>
-
-  <!-- Filter chips + batch toolbar -->
-  <div class="flex items-center gap-2 flex-wrap">
-    <div role="radiogroup" aria-label="Filter by status" class="flex gap-2 flex-wrap flex-1">
-      {#each filters as f}
-        <button
-          role="radio"
-          aria-checked={filter === f}
-          onclick={() => (filter = f)}
-          class="filter-chip px-3 py-1.5 rounded-lg text-sm font-medium capitalize"
-          style={filter === f
-            ? "background: color-mix(in srgb, var(--neon-primary) 15%, transparent); color: var(--neon-primary)"
-            : "background: var(--bg-surface); color: var(--text-secondary)"}
-        >
-          {f}
-          {#if f === "all"}
-            <span class="ml-1 opacity-50">{allDownloads().length}</span>
-          {:else}
-            <span class="ml-1 opacity-50">{countByStatus(f)}</span>
-          {/if}
-        </button>
-      {/each}
-    </div>
-
-    <!-- Batch select toggle -->
-    {#if filtered.length > 0}
-      <button
-        onclick={handleSelectAll}
-        class="filter-chip px-3 py-1.5 rounded-lg text-sm font-medium"
-        style={batchMode
-          ? "background: color-mix(in srgb, var(--neon-primary) 15%, transparent); color: var(--neon-primary)"
-          : "background: var(--bg-surface); color: var(--text-secondary)"}
-        aria-label="Select all"
-      >
-        <Icon name="check" size={14} />
-        {#if batchMode}
-          <span class="ml-1">{$selectedIds.size}</span>
-        {/if}
-      </button>
-    {/if}
   </div>
 
   <!-- Batch actions bar -->
   {#if batchMode}
-    <div class="flex items-center gap-2 px-3 py-2 rounded-lg" style="background: var(--bg-surface); border: 1px solid var(--border-color)">
-      <span class="text-xs font-semibold" style="color: var(--text-secondary)">{$selectedIds.size} selected</span>
+    <div class="flex items-center gap-2 px-3 py-2 rounded-lg flex-wrap" style="background: var(--bg-surface); border: 1px solid var(--border-color)">
+      <span class="text-xs font-semibold" style="color: var(--text-secondary)">{$selectedIds.size} {tr($locale, "downloads.selected")}</span>
       <div class="flex-1"></div>
       <button onclick={batchPause} class="action-btn flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold" style="background: var(--bg-surface-2); color: var(--neon-warning)">
-        <Icon name="pause" size={14} /> Pause
+        <Icon name="pause" size={14} /> {tr($locale, "batch.pause")}
       </button>
       <button onclick={batchResume} class="action-btn flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold" style="background: var(--bg-surface-2); color: var(--neon-primary)">
-        <Icon name="play" size={14} /> Resume
+        <Icon name="play" size={14} /> {tr($locale, "batch.resume")}
       </button>
       <button onclick={batchDelete} class="action-btn flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold" style="background: var(--bg-surface-2); color: var(--neon-accent)">
-        <Icon name="trash" size={14} /> {confirmingBatchDelete ? "Sure?" : "Delete"}
+        <Icon name="trash" size={14} /> {confirmingBatchDelete ? tr($locale, "batch.confirm") : tr($locale, "batch.delete")}
       </button>
-      <button onclick={clearSelection} class="icon-btn p-1.5 rounded-lg" style="color: var(--text-secondary)" aria-label="Clear selection">
+      <button onclick={clearSelection} class="icon-btn p-1.5 rounded-lg" style="color: var(--text-secondary)" aria-label={tr($locale, "downloads.clear_selection")}>
         <Icon name="x" size={14} />
       </button>
     </div>
   {/if}
 
   <!-- Download list -->
-  {#if filtered.length === 0}
-    <div class="flex flex-col items-center justify-center py-20">
-      <img src="/amigo-logo.png" alt="" width="64" height="64" class="rounded-lg opacity-30" />
-      <p class="mt-4 text-sm" style="color: var(--text-secondary)">No downloads yet</p>
-      <button
-        onclick={() => openAddPanel()}
-        class="mt-4 flex items-center gap-2 px-4 py-2.5 rounded-lg text-sm font-semibold transition-colors"
-        style="background: var(--neon-primary); color: var(--bg-deep)"
-      >
-        <Icon name="plus" size={16} />
-        Add your first download
-      </button>
-      <p class="text-xs mt-3" style="color: var(--text-secondary); opacity: 0.5">Ctrl+N to add &middot; Drag & drop supported</p>
-    </div>
-  {:else}
-    {#if viewMode === "grid"}
-      <div class="grid gap-3">
-        {#each filtered as download, i (download.id)}
-          <DownloadCard
-          {download}
-          index={i}
-          ondragstart={handleDragStart(download.id)}
-          ondragover={handleDragOver}
-          ondrop={handleDrop(download.id)}
-        />
-        {/each}
+  {#if showSkeleton}
+    <SkeletonCard count={5} />
+  {:else if filtered.length === 0}
+    {#if emptyKey}
+      <!-- Context-aware empty state (specific filter / search) -->
+      <div class="flex flex-col items-center justify-center py-20 text-center">
+        <Icon name="search" size={32} />
+        <p class="mt-4 text-sm" style="color: var(--text-secondary)">{tr($locale, emptyKey)}</p>
       </div>
     {:else}
-      <div class="flex flex-col gap-1">
-        {#each filtered as download (download.id)}
-          <DownloadCompactRow {download} />
-        {/each}
+      <!-- First-run empty state -->
+      <div class="flex flex-col items-center justify-center py-20 text-center">
+        <img src="/amigo-logo.png" alt="" width="64" height="64" class="rounded-lg opacity-30" />
+        <p class="mt-4 text-sm" style="color: var(--text-secondary)">{tr($locale, "downloads.no_downloads")}</p>
+        <button
+          onclick={() => openAddPanel()}
+          class="action-btn mt-4 flex items-center gap-2 px-4 py-2.5 rounded-lg text-sm font-semibold"
+          style="background: var(--neon-primary); color: var(--bg-deep); box-shadow: var(--neon-glow-sm)"
+        >
+          <Icon name="plus" size={16} />
+          {tr($locale, "downloads.add_first")}
+        </button>
+        <p class="text-xs mt-3" style="color: var(--text-secondary); opacity: 0.5">{tr($locale, "downloads.add_hint")}</p>
       </div>
     {/if}
+  {:else if viewMode === "grid"}
+    <div class="grid gap-3">
+      {#each filtered as download, i (download.id)}
+        <div animate:flip={flipConfig}>
+          <DownloadCard
+            {download}
+            index={i}
+            ondragstart={handleDragStart(download.id)}
+            ondragover={handleDragOver}
+            ondrop={handleDrop(download.id)}
+          />
+        </div>
+      {/each}
+    </div>
+  {:else}
+    <div class="flex flex-col gap-1">
+      {#each filtered as download (download.id)}
+        <div animate:flip={flipConfig}>
+          <DownloadCompactRow {download} />
+        </div>
+      {/each}
+    </div>
   {/if}
 </div>
+
+<style>
+  /* Toolbar sticks to the top of the scroll container so search/filters stay
+     reachable in long lists. Slightly translucent so cards scroll under it. */
+  .toolbar-sticky {
+    position: sticky;
+    top: 0;
+    z-index: 20;
+    background: color-mix(in srgb, var(--bg-deep) 88%, transparent);
+    backdrop-filter: blur(8px);
+  }
+
+  /* Hide the scrollbar on the filter rail — it scrolls by drag/swipe. */
+  .chip-rail {
+    scrollbar-width: none;
+  }
+  .chip-rail::-webkit-scrollbar {
+    display: none;
+  }
+</style>

--- a/web-ui/src/pages/Settings.svelte
+++ b/web-ui/src/pages/Settings.svelte
@@ -3,7 +3,7 @@
   import { features } from "../lib/stores";
   import { getConfig, putConfig, getWebhooks, type AppConfig } from "../lib/api";
   import { addToast } from "../lib/toast";
-  import { locale, type Locale } from "../lib/i18n";
+  import { locale, tr, type Locale } from "../lib/i18n";
   import Icon from "@amigo/ui/components/Icon.svelte";
 
   import SettingsFeatures from "../components/settings/SettingsFeatures.svelte";
@@ -32,9 +32,9 @@
     try {
       config = await putConfig(config);
       features.set(config.features);
-      addToast("success", "Settings saved");
+      addToast("success", tr($locale, "settings.saved"));
     } catch {
-      addToast("error", "Failed to save settings");
+      addToast("error", tr($locale, "settings.save_failed"));
     }
   }
 </script>
@@ -55,7 +55,7 @@
 
   <!-- Language -->
   <section>
-    <h3 class="text-lg font-bold mb-4" style="color: var(--text-primary)">Language</h3>
+    <h3 class="text-lg font-bold mb-4" style="color: var(--text-primary)">{tr($locale, "settings.language")}</h3>
     <div class="rounded-xl p-5" style="background: var(--bg-surface); border: 1px solid var(--border-color)">
       <div class="flex items-center gap-3">
         <Icon name="globe" size={18} />
@@ -64,7 +64,7 @@
           onchange={(e) => locale.set((e.target as HTMLSelectElement).value as Locale)}
           class="flex-1 rounded-lg px-3 py-2 text-sm"
           style="background: var(--bg-surface-2); border: 1px solid var(--border-color); color: var(--text-primary)"
-          aria-label="Language"
+          aria-label={tr($locale, "settings.language")}
         >
           <option value="en" style="background: var(--bg-surface-2)">English</option>
           <option value="de" style="background: var(--bg-surface-2)">Deutsch</option>
@@ -75,7 +75,7 @@
 
   <!-- About -->
   <section>
-    <h3 class="text-lg font-bold mb-4" style="color: var(--text-primary)">About</h3>
+    <h3 class="text-lg font-bold mb-4" style="color: var(--text-primary)">{tr($locale, "settings.about")}</h3>
     <div class="rounded-xl p-5" style="background: var(--bg-surface); border: 1px solid var(--border-color)">
       <div class="flex items-center gap-4">
         <img src="/amigo-logo.png" alt="amigo-downloader" width="40" height="40" class="rounded-lg" />


### PR DESCRIPTION
## Summary

A bold UI/UX redesign of the web UI ("Command Deck"), elevating it into a coherent, mobile-first power-user surface — built **within** the existing Corporate Neon token system, not on top of a rewrite. Covers all four requested focus areas: **visual polish & motion**, **mobile & responsive**, **accessibility & i18n**, and **core flows & clarity**.

## Headline changes

- **⌘/Ctrl+K Command Palette** (`CommandPalette.svelte`) — fuzzy nav + actions (add download, switch page, toggle theme, pick palette, set neon intensity, shortcuts). Focus-trapped, arrow/enter driven. Discoverable via a header trigger and sidebar button.
- **Mobile bottom navigation + Add FAB** (`MobileNav.svelte`) replaces the hamburger overlay — thumb-reachable, safe-area aware, `aria-current` on active tab.
- **Persistent global status bar** in the header (aggregate speed + sparkline, active ring, queued, done) — status at a glance from any page, responsive down to mobile.
- **Shared motion system** (`tokens.css` easing/duration vars + `lib/motion.ts`): FLIP list animations so filter/sort/reorder glide instead of jump, a house `scaleFade` transition for dialogs/popovers, all reduced-motion-aware.

## Core flows & clarity

- Downloads: **sticky responsive toolbar** (no overflow at 320px; filter chips scroll), **skeleton loading** on first fetch (previously an empty flash), **context-aware empty states** (per-filter / search vs. first-run CTA), tabular-nums figures, smoother progress.
- AddPanel: **live link detection + validation** ("N links detected", flags non-URL lines, gates submit).
- Toasts: **action buttons** with **Undo** wired into single + batch delete, per-type durations (errors linger), pause-on-hover, type glyphs (non-color cue), animated enter/exit.

## Accessibility & i18n

- **Reusable focus-trap action** (`lib/focusTrap.ts`) applied to command palette, captcha, shortcuts, feedback, and the mobile side panel — focus restored on close.
- `aria-current="page"` on nav; `aria-pressed` on toggles; backdrops converted to buttons; form labels properly associated (svelte-check a11y warnings 43 → 28).
- **i18n completion** (`lib/i18n.ts`): added an interpolation helper and a full key set; translated Settings panels, captcha, shortcuts, side panel, downloads, cards, add panel, nav — no hardcoded English left in the touched views (en + de).

## Verification

- `pnpm --filter amigo-web-ui check` → **0 errors** (warnings reduced 43 → 28, all pre-existing in untouched Usenet/RSS forms).
- `pnpm --filter amigo-web-ui build` → succeeds.
- Vite dev server smoke test: index + all new/modified modules transform with HTTP 200.

> Note: full interactive QA of the ready-state UI requires the `amigo-server` backend (the boot gate otherwise lands on Login), which isn't running in this environment. Recommend a manual pass with the server up: resize 320→2560, ⌘K palette, add/undo flows, locale de/en, all 6 palettes in light+dark, and an OS reduced-motion check.

🤖 Generated with [Claude Code](https://claude.ai/code)
https://claude.ai/code/session_01MaKRTS9chSdjrYyZnixfqe

---
_Generated by [Claude Code](https://claude.ai/code/session_01MaKRTS9chSdjrYyZnixfqe)_